### PR TITLE
Add APIs to normalize arbitrary `char` iterators rather than just `str`.

### DIFF
--- a/src/decompose.rs
+++ b/src/decompose.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::str::Chars;
 
 // Helper functions used for Unicode normalization
 fn canonical_sort(comb: &mut [(char, u8)]) {
@@ -35,17 +34,17 @@ enum DecompositionType {
 
 /// External iterator for a string decomposition's characters.
 #[derive(Clone)]
-pub struct Decompositions<'a> {
+pub struct Decompositions<I> {
     kind: DecompositionType,
-    iter: Chars<'a>,
+    iter: I,
     buffer: Vec<(char, u8)>,
     sorted: bool
 }
 
 #[inline]
-pub fn new_canonical<'a>(s: &'a str) -> Decompositions<'a> {
+pub fn new_canonical<I: Iterator<Item=char>>(iter: I) -> Decompositions<I> {
     Decompositions {
-        iter: s.chars(),
+        iter: iter,
         buffer: Vec::new(),
         sorted: false,
         kind: self::DecompositionType::Canonical,
@@ -53,16 +52,16 @@ pub fn new_canonical<'a>(s: &'a str) -> Decompositions<'a> {
 }
 
 #[inline]
-pub fn new_compatible<'a>(s: &'a str) -> Decompositions<'a> {
+pub fn new_compatible<I: Iterator<Item=char>>(iter: I) -> Decompositions<I> {
     Decompositions {
-        iter: s.chars(),
+        iter: iter,
         buffer: Vec::new(),
         sorted: false,
         kind: self::DecompositionType::Compatible,
     }
 }
 
-impl<'a> Iterator for Decompositions<'a> {
+impl<I: Iterator<Item=char>> Iterator for Decompositions<I> {
     type Item = char;
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,52 +63,107 @@ pub mod char {
 
 /// Methods for applying composition and decomposition to strings.
 pub mod str {
+    use std::str::Chars;
+
     pub use super::decompose::Decompositions;
     pub use super::recompose::Recompositions;
 
     /// Methods for iterating over strings while applying Unicode normalizations
-    /// as described in 
+    /// as described in
     /// [Unicode Standard Annex #15](http://www.unicode.org/reports/tr15/).
     pub trait UnicodeNormalization {
         /// Returns an iterator over the string in Unicode Normalization Form D
         /// (canonical decomposition).
         #[inline]
-        fn nfd_chars(&self) -> Decompositions;
+        fn nfd_chars(&self) -> Decompositions<Chars>;
 
         /// Returns an iterator over the string in Unicode Normalization Form KD
         /// (compatibility decomposition).
         #[inline]
-        fn nfkd_chars(&self) -> Decompositions;
+        fn nfkd_chars(&self) -> Decompositions<Chars>;
 
         /// An Iterator over the string in Unicode Normalization Form C
         /// (canonical decomposition followed by canonical composition).
         #[inline]
-        fn nfc_chars(&self) -> Recompositions;
+        fn nfc_chars(&self) -> Recompositions<Chars>;
 
         /// An Iterator over the string in Unicode Normalization Form KC
         /// (compatibility decomposition followed by canonical composition).
         #[inline]
-        fn nfkc_chars(&self) -> Recompositions;
+        fn nfkc_chars(&self) -> Recompositions<Chars>;
     }
 
     impl UnicodeNormalization for str {
         #[inline]
-        fn nfd_chars(&self) -> Decompositions {
+        fn nfd_chars(&self) -> Decompositions<Chars> {
+            super::decompose::new_canonical(self.chars())
+        }
+
+        #[inline]
+        fn nfkd_chars(&self) -> Decompositions<Chars> {
+            super::decompose::new_compatible(self.chars())
+        }
+
+        #[inline]
+        fn nfc_chars(&self) -> Recompositions<Chars> {
+            super::recompose::new_canonical(self.chars())
+        }
+
+        #[inline]
+        fn nfkc_chars(&self) -> Recompositions<Chars> {
+            super::recompose::new_compatible(self.chars())
+        }
+    }
+}
+
+/// Methods for applying composition and decomposition to char iterators.
+pub mod iter {
+    pub use super::decompose::Decompositions;
+    pub use super::recompose::Recompositions;
+
+    /// Methods for adapting iterators while applying Unicode normalizations
+    /// as described in
+    /// [Unicode Standard Annex #15](http://www.unicode.org/reports/tr15/).
+    pub trait UnicodeNormalization<I> {
+        /// Returns an iterator in Unicode Normalization Form D
+        /// (canonical decomposition).
+        #[inline]
+        fn nfd_chars(self) -> Decompositions<I>;
+
+        /// Returns an iterator in Unicode Normalization Form KD
+        /// (compatibility decomposition).
+        #[inline]
+        fn nfkd_chars(self) -> Decompositions<I>;
+
+        /// An Iterator in Unicode Normalization Form C
+        /// (canonical decomposition followed by canonical composition).
+        #[inline]
+        fn nfc_chars(self) -> Recompositions<I>;
+
+        /// An Iterator in Unicode Normalization Form KC
+        /// (compatibility decomposition followed by canonical composition).
+        #[inline]
+        fn nfkc_chars(self) -> Recompositions<I>;
+    }
+
+    impl<I: Iterator<Item=char>> UnicodeNormalization<I> for I {
+        #[inline]
+        fn nfd_chars(self) -> Decompositions<I> {
             super::decompose::new_canonical(self)
         }
 
         #[inline]
-        fn nfkd_chars(&self) -> Decompositions {
+        fn nfkd_chars(self) -> Decompositions<I> {
             super::decompose::new_compatible(self)
         }
 
         #[inline]
-        fn nfc_chars(&self) -> Recompositions {
+        fn nfc_chars(self) -> Recompositions<I> {
             super::recompose::new_canonical(self)
         }
 
         #[inline]
-        fn nfkc_chars(&self) -> Recompositions {
+        fn nfkc_chars(self) -> Recompositions<I> {
             super::recompose::new_compatible(self)
         }
     }

--- a/src/recompose.rs
+++ b/src/recompose.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use std::collections::VecDeque;
-use super::str::{Decompositions, UnicodeNormalization};
+use super::str::Decompositions;
 
 #[derive(Clone)]
 enum RecompositionState {
@@ -20,8 +20,8 @@ enum RecompositionState {
 
 /// External iterator for a string recomposition's characters.
 #[derive(Clone)]
-pub struct Recompositions<'a> {
-    iter: Decompositions<'a>,
+pub struct Recompositions<I> {
+    iter: Decompositions<I>,
     state: RecompositionState,
     buffer: VecDeque<char>,
     composee: Option<char>,
@@ -29,9 +29,9 @@ pub struct Recompositions<'a> {
 }
 
 #[inline]
-pub fn new_canonical<'a>(s: &'a str) -> Recompositions<'a> {
+pub fn new_canonical<I: Iterator<Item=char>>(iter: I) -> Recompositions<I> {
     Recompositions {
-        iter: UnicodeNormalization::nfd_chars(s),
+        iter: super::decompose::new_canonical(iter),
         state: self::RecompositionState::Composing,
         buffer: VecDeque::new(),
         composee: None,
@@ -40,9 +40,9 @@ pub fn new_canonical<'a>(s: &'a str) -> Recompositions<'a> {
 }
 
 #[inline]
-pub fn new_compatible<'a>(s: &'a str) -> Recompositions<'a> {
+pub fn new_compatible<I: Iterator<Item=char>>(iter: I) -> Recompositions<I> {
     Recompositions {
-        iter: UnicodeNormalization::nfkd_chars(s),
+        iter: super::decompose::new_compatible(iter),
         state : self::RecompositionState::Composing,
         buffer: VecDeque::new(),
         composee: None,
@@ -50,7 +50,7 @@ pub fn new_compatible<'a>(s: &'a str) -> Recompositions<'a> {
     }
 }
 
-impl<'a> Iterator for Recompositions<'a> {
+impl<I: Iterator<Item=char>> Iterator for Recompositions<I> {
     type Item = char;
 
     #[inline]


### PR DESCRIPTION
This enables not allocating memory for intermediate results in [algorithms](https://github.com/SimonSapin/rust-caseless/blob/fb1158aa6c59e892779a62099ff413eb8c57eeba/src/lib.rs#L94-L99) like this part of Unicode’s [*canonical caseless matching*](http://www.unicode.org/versions/Unicode7.0.0/ch03.pdf#G34145):

```rust
nfkd(default_case_fold(nfkd(default_case_fold(nfd(input)))))
```

This API is a “straw man” proposal. I don’t really like duplicating the trait, but I didn’t manage to get two implementation (for strings and iterators) of the same trait to not conflict.

Another option is to only take iterators as input, and users that have a `str` can just call `.chars()` on it.