### PR TITLE
Replace the `str` methods by functions that take abritrary `char` iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ as described in
 extern crate unicode_normalization;
 
 use unicode_normalization::char::compose;
-use unicode_normalization::str::UnicodeNormalization;
+use unicode_normalization::nfc;
 
 fn main() {
     assert_eq!(compose('A','\u{30a}'), Some('Å'));
-    
+
     let s = "ÅΩ";
-    let c = UnicodeNormalization::nfc_chars(s).collect::<String>();
+    let c = nfc(s.chars()).collect::<String>();
     assert_eq!(c, "ÅΩ");
 }
 ```

--- a/src/decompose.rs
+++ b/src/decompose.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::str::Chars;
 
 // Helper functions used for Unicode normalization
 fn canonical_sort(comb: &mut [(char, u8)]) {
@@ -35,34 +34,36 @@ enum DecompositionType {
 
 /// External iterator for a string decomposition's characters.
 #[derive(Clone)]
-pub struct Decompositions<'a> {
+pub struct Decompositions<I> {
     kind: DecompositionType,
-    iter: Chars<'a>,
+    iter: I,
     buffer: Vec<(char, u8)>,
     sorted: bool
 }
 
+/// Transform a `char` iterator into Unicode Normalization Form D (canonical decomposition).
 #[inline]
-pub fn new_canonical<'a>(s: &'a str) -> Decompositions<'a> {
+pub fn nfd<I: Iterator<Item=char>>(iter: I) -> Decompositions<I> {
     Decompositions {
-        iter: s.chars(),
+        iter: iter,
         buffer: Vec::new(),
         sorted: false,
-        kind: self::DecompositionType::Canonical,
+        kind: DecompositionType::Canonical,
     }
 }
 
+/// Transform a `char` iterator into Unicode Normalization Form KD (compatibility decomposition).
 #[inline]
-pub fn new_compatible<'a>(s: &'a str) -> Decompositions<'a> {
+pub fn nfkd<I: Iterator<Item=char>>(iter: I) -> Decompositions<I> {
     Decompositions {
-        iter: s.chars(),
+        iter: iter,
         buffer: Vec::new(),
         sorted: false,
-        kind: self::DecompositionType::Compatible,
+        kind: DecompositionType::Compatible,
     }
 }
 
-impl<'a> Iterator for Decompositions<'a> {
+impl<I: Iterator<Item=char>> Iterator for Decompositions<I> {
     type Item = char;
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,13 @@
 //! extern crate unicode_normalization;
 //!
 //! use unicode_normalization::char::compose;
-//! use unicode_normalization::str::UnicodeNormalization;
+//! use unicode_normalization::nfc;
 //!
 //! fn main() {
 //!     assert_eq!(compose('A','\u{30a}'), Some('Å'));
-//!     
+//!
 //!     let s = "ÅΩ";
-//!     let c = UnicodeNormalization::nfc_chars(s).collect::<String>();
+//!     let c = nfc(s.chars()).collect::<String>();
 //!     assert_eq!(c, "ÅΩ");
 //! }
 //! ```
@@ -42,6 +42,8 @@
        html_favicon_url = "https://unicode-rs.github.io/unicode-rs_sm.png")]
 
 pub use tables::UNICODE_VERSION;
+pub use decompose::{nfd, nfkd, Decompositions};
+pub use recompose::{nfc, nfkc, Recompositions};
 
 mod decompose;
 mod normalize;
@@ -59,57 +61,4 @@ pub mod char {
 
     /// Look up the canonical combining class of a character.
     pub use tables::normalization::canonical_combining_class;
-}
-
-/// Methods for applying composition and decomposition to strings.
-pub mod str {
-    pub use super::decompose::Decompositions;
-    pub use super::recompose::Recompositions;
-
-    /// Methods for iterating over strings while applying Unicode normalizations
-    /// as described in 
-    /// [Unicode Standard Annex #15](http://www.unicode.org/reports/tr15/).
-    pub trait UnicodeNormalization {
-        /// Returns an iterator over the string in Unicode Normalization Form D
-        /// (canonical decomposition).
-        #[inline]
-        fn nfd_chars(&self) -> Decompositions;
-
-        /// Returns an iterator over the string in Unicode Normalization Form KD
-        /// (compatibility decomposition).
-        #[inline]
-        fn nfkd_chars(&self) -> Decompositions;
-
-        /// An Iterator over the string in Unicode Normalization Form C
-        /// (canonical decomposition followed by canonical composition).
-        #[inline]
-        fn nfc_chars(&self) -> Recompositions;
-
-        /// An Iterator over the string in Unicode Normalization Form KC
-        /// (compatibility decomposition followed by canonical composition).
-        #[inline]
-        fn nfkc_chars(&self) -> Recompositions;
-    }
-
-    impl UnicodeNormalization for str {
-        #[inline]
-        fn nfd_chars(&self) -> Decompositions {
-            super::decompose::new_canonical(self)
-        }
-
-        #[inline]
-        fn nfkd_chars(&self) -> Decompositions {
-            super::decompose::new_compatible(self)
-        }
-
-        #[inline]
-        fn nfc_chars(&self) -> Recompositions {
-            super::recompose::new_canonical(self)
-        }
-
-        #[inline]
-        fn nfkc_chars(&self) -> Recompositions {
-            super::recompose::new_compatible(self)
-        }
-    }
 }

--- a/src/recompose.rs
+++ b/src/recompose.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use std::collections::VecDeque;
-use super::str::{Decompositions, UnicodeNormalization};
+use decompose::{nfd, nfkd, Decompositions};
 
 #[derive(Clone)]
 enum RecompositionState {
@@ -20,37 +20,41 @@ enum RecompositionState {
 
 /// External iterator for a string recomposition's characters.
 #[derive(Clone)]
-pub struct Recompositions<'a> {
-    iter: Decompositions<'a>,
+pub struct Recompositions<I> {
+    iter: Decompositions<I>,
     state: RecompositionState,
     buffer: VecDeque<char>,
     composee: Option<char>,
     last_ccc: Option<u8>
 }
 
+/// Transform a `char` iterator into Unicode Normalization Form C
+/// (canonical decomposition followed by canonical composition).
 #[inline]
-pub fn new_canonical<'a>(s: &'a str) -> Recompositions<'a> {
+pub fn nfc<I: Iterator<Item=char>>(iter: I) -> Recompositions<I> {
     Recompositions {
-        iter: UnicodeNormalization::nfd_chars(s),
-        state: self::RecompositionState::Composing,
+        iter: nfd(iter),
+        state: RecompositionState::Composing,
         buffer: VecDeque::new(),
         composee: None,
         last_ccc: None,
     }
 }
 
+/// Transform a `char` iterator into Unicode Normalization Form KC
+/// (compatibility decomposition followed by canonical composition).
 #[inline]
-pub fn new_compatible<'a>(s: &'a str) -> Recompositions<'a> {
+pub fn nfkc<I: Iterator<Item=char>>(iter: I) -> Recompositions<I> {
     Recompositions {
-        iter: UnicodeNormalization::nfkd_chars(s),
-        state : self::RecompositionState::Composing,
+        iter: nfkd(iter),
+        state : RecompositionState::Composing,
         buffer: VecDeque::new(),
         composee: None,
         last_ccc: None,
     }
 }
 
-impl<'a> Iterator for Recompositions<'a> {
+impl<I: Iterator<Item=char>> Iterator for Recompositions<I> {
     type Item = char;
 
     #[inline]

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::str::UnicodeNormalization;
+use super::{nfd, nfkd, nfc, nfkc};
 
 #[test]
-fn test_nfd_chars() {
+fn test_nfd() {
     macro_rules! t {
         ($input: expr, $expected: expr) => {
-            assert_eq!(UnicodeNormalization::nfd_chars($input).collect::<String>(), $expected);
+            assert_eq!(nfd($input.chars()).collect::<String>(), $expected);
         }
     }
     t!("abc", "abc");
@@ -30,10 +30,10 @@ fn test_nfd_chars() {
 }
 
 #[test]
-fn test_nfkd_chars() {
+fn test_nfkd() {
     macro_rules! t {
         ($input: expr, $expected: expr) => {
-            assert_eq!(UnicodeNormalization::nfkd_chars($input).collect::<String>(), $expected);
+            assert_eq!(nfkd($input.chars()).collect::<String>(), $expected);
         }
     }
     t!("abc", "abc");
@@ -49,10 +49,10 @@ fn test_nfkd_chars() {
 }
 
 #[test]
-fn test_nfc_chars() {
+fn test_nfc() {
     macro_rules! t {
         ($input: expr, $expected: expr) => {
-            assert_eq!(UnicodeNormalization::nfc_chars($input).collect::<String>(), $expected);
+            assert_eq!(nfc($input.chars()).collect::<String>(), $expected);
         }
     }
     t!("abc", "abc");
@@ -69,10 +69,10 @@ fn test_nfc_chars() {
 }
 
 #[test]
-fn test_nfkc_chars() {
+fn test_nfkc() {
     macro_rules! t {
         ($input: expr, $expected: expr) => {
-            assert_eq!(UnicodeNormalization::nfkc_chars($input).collect::<String>(), $expected);
+            assert_eq!(nfkc($input.chars()).collect::<String>(), $expected);
         }
     }
     t!("abc", "abc");
@@ -92,18 +92,18 @@ fn test_nfkc_chars() {
 fn test_official() {
     use testdata::TEST_NORM;
     macro_rules! normString {
-        ($fun: ident, $input: expr) => { UnicodeNormalization::$fun($input).collect::<String>() }
+        ($fun: ident, $input: expr) => { $fun($input.chars()).collect::<String>() }
     }
 
     for &(s1, s2, s3, s4, s5) in TEST_NORM {
         // these invariants come from the CONFORMANCE section of
         // http://www.unicode.org/Public/UNIDATA/NormalizationTest.txt
         {
-            let r1 = normString!(nfc_chars, s1);
-            let r2 = normString!(nfc_chars, s2);
-            let r3 = normString!(nfc_chars, s3);
-            let r4 = normString!(nfc_chars, s4);
-            let r5 = normString!(nfc_chars, s5);
+            let r1 = normString!(nfc, s1);
+            let r2 = normString!(nfc, s2);
+            let r3 = normString!(nfc, s3);
+            let r4 = normString!(nfc, s4);
+            let r5 = normString!(nfc, s5);
             assert_eq!(s2, &r1[..]);
             assert_eq!(s2, &r2[..]);
             assert_eq!(s2, &r3[..]);
@@ -112,11 +112,11 @@ fn test_official() {
         }
 
         {
-            let r1 = normString!(nfd_chars, s1);
-            let r2 = normString!(nfd_chars, s2);
-            let r3 = normString!(nfd_chars, s3);
-            let r4 = normString!(nfd_chars, s4);
-            let r5 = normString!(nfd_chars, s5);
+            let r1 = normString!(nfd, s1);
+            let r2 = normString!(nfd, s2);
+            let r3 = normString!(nfd, s3);
+            let r4 = normString!(nfd, s4);
+            let r5 = normString!(nfd, s5);
             assert_eq!(s3, &r1[..]);
             assert_eq!(s3, &r2[..]);
             assert_eq!(s3, &r3[..]);
@@ -125,11 +125,11 @@ fn test_official() {
         }
 
         {
-            let r1 = normString!(nfkc_chars, s1);
-            let r2 = normString!(nfkc_chars, s2);
-            let r3 = normString!(nfkc_chars, s3);
-            let r4 = normString!(nfkc_chars, s4);
-            let r5 = normString!(nfkc_chars, s5);
+            let r1 = normString!(nfkc, s1);
+            let r2 = normString!(nfkc, s2);
+            let r3 = normString!(nfkc, s3);
+            let r4 = normString!(nfkc, s4);
+            let r5 = normString!(nfkc, s5);
             assert_eq!(s4, &r1[..]);
             assert_eq!(s4, &r2[..]);
             assert_eq!(s4, &r3[..]);
@@ -138,11 +138,11 @@ fn test_official() {
         }
 
         {
-            let r1 = normString!(nfkd_chars, s1);
-            let r2 = normString!(nfkd_chars, s2);
-            let r3 = normString!(nfkd_chars, s3);
-            let r4 = normString!(nfkd_chars, s4);
-            let r5 = normString!(nfkd_chars, s5);
+            let r1 = normString!(nfkd, s1);
+            let r2 = normString!(nfkd, s2);
+            let r3 = normString!(nfkd, s3);
+            let r4 = normString!(nfkd, s4);
+            let r5 = normString!(nfkd, s5);
             assert_eq!(s5, &r1[..]);
             assert_eq!(s5, &r2[..]);
             assert_eq!(s5, &r3[..]);


### PR DESCRIPTION
This enables not allocating memory for intermediate results in algorithms like this part of Unicode’s [*canonical caseless matching*](http://www.unicode.org/versions/Unicode7.0.0/ch03.pdf#G34145 ):

```rust
nfkd(default_case_fold(nfkd(default_case_fold(nfd(input)))))
```

Closes #2. (This is an alternative to it.)