### PR TITLE
Implement Display for Recompositions, Decompositions

### DIFF
--- a/src/decompose.rs
+++ b/src/decompose.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::fmt::{self, Write};
 
 // Helper functions used for Unicode normalization
 fn canonical_sort(comb: &mut [(char, u8)]) {
@@ -131,5 +132,14 @@ impl<I: Iterator<Item=char>> Iterator for Decompositions<I> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lower, _) = self.iter.size_hint();
         (lower, None)
+    }
+}
+
+impl<I: Iterator<Item=char> + Clone> fmt::Display for Decompositions<I> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for c in self.clone() {
+            f.write_char(c)?;
+        }
+        Ok(())
     }
 }

--- a/src/recompose.rs
+++ b/src/recompose.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use std::collections::VecDeque;
+use std::fmt::{self, Write};
 use decompose::Decompositions;
 
 #[derive(Clone)]
@@ -133,5 +134,14 @@ impl<I: Iterator<Item=char>> Iterator for Recompositions<I> {
                 }
             }
         }
+    }
+}
+
+impl<I: Iterator<Item=char> + Clone> fmt::Display for Recompositions<I> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for c in self.clone() {
+            f.write_char(c)?;
+        }
+        Ok(())
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -14,8 +14,9 @@ use UnicodeNormalization;
 fn test_nfd() {
     macro_rules! t {
         ($input: expr, $expected: expr) => {
-            assert_eq!($input.nfd().collect::<String>(), $expected);
-            // A dummy iterator that is not std::str::Chars directly:
+            assert_eq!($input.nfd().to_string(), $expected);
+            // A dummy iterator that is not std::str::Chars directly;
+            // note that `id_func` is used to ensure `Clone` implementation
             assert_eq!($input.chars().map(|c| c).nfd().collect::<String>(), $expected);
         }
     }
@@ -35,7 +36,7 @@ fn test_nfd() {
 fn test_nfkd() {
     macro_rules! t {
         ($input: expr, $expected: expr) => {
-            assert_eq!($input.nfkd().collect::<String>(), $expected);
+            assert_eq!($input.nfkd().to_string(), $expected);
         }
     }
     t!("abc", "abc");
@@ -54,7 +55,7 @@ fn test_nfkd() {
 fn test_nfc() {
     macro_rules! t {
         ($input: expr, $expected: expr) => {
-            assert_eq!($input.nfc().collect::<String>(), $expected);
+            assert_eq!($input.nfc().to_string(), $expected);
         }
     }
     t!("abc", "abc");
@@ -74,7 +75,7 @@ fn test_nfc() {
 fn test_nfkc() {
     macro_rules! t {
         ($input: expr, $expected: expr) => {
-            assert_eq!($input.nfkc().collect::<String>(), $expected);
+            assert_eq!($input.nfkc().to_string(), $expected);
         }
     }
     t!("abc", "abc");


### PR DESCRIPTION
This requires a `Clone` implementation for the iterator, but this isn't a problem because the default implementations do.