### PR TITLE
Ignore .txt files so that they don't get published

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 scripts/tmp
 *.pyc
+*.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "unicode-normalization"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["kwantam <kwantam@gmail.com>"]
 
 homepage = "https://github.com/unicode-rs/unicode-normalization"
@@ -18,4 +18,4 @@ Decomposition and Recomposition, as described in
 Unicode Standard Annex #15.
 """
 
-exclude = [ "target/*", "Cargo.lock", "scripts/tmp" ]
+exclude = [ "target/*", "Cargo.lock", "scripts/tmp", "*.txt" ]


### PR DESCRIPTION
Current published crate contains ALL TEH UNICODEZ and is many megabytes in size. We don't need these tables except when hacking on the crate locally, and we should remove it.

Please re-publish after this.


r? @SimonSapin @kwantam