### PR TITLE
Implement stream-safe text process (UAX15-D4)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,11 @@ pub trait UnicodeNormalization<I: Iterator<Item=char>> {
     #[inline]
     fn nfd(self) -> Decompositions<I>;
 
+    /// Returns an iterator over the string in Unicode Normalization Form D
+    /// (canonical decomposition), with the UAX15-D4 stream-safe extension.
+    #[inline]
+    fn nfd_stream_safe(self) -> Decompositions<I>;
+
     /// Returns an iterator over the string in Unicode Normalization Form KD
     /// (compatibility decomposition).
     #[inline]
@@ -87,6 +92,12 @@ pub trait UnicodeNormalization<I: Iterator<Item=char>> {
     #[inline]
     fn nfc(self) -> Recompositions<I>;
 
+    #[inline]
+    /// An Iterator over the string in Unicode Normalization Form C (canonical
+    /// decomposition followed by canonical composition), with the UAX15-D4
+    /// stream-safe extension.
+    fn nfc_stream_safe(self) -> Recompositions<I>;
+
     /// An Iterator over the string in Unicode Normalization Form KC
     /// (compatibility decomposition followed by canonical composition).
     #[inline]
@@ -96,43 +107,63 @@ pub trait UnicodeNormalization<I: Iterator<Item=char>> {
 impl<'a> UnicodeNormalization<Chars<'a>> for &'a str {
     #[inline]
     fn nfd(self) -> Decompositions<Chars<'a>> {
-        decompose::new_canonical(self.chars())
+        decompose::new_canonical(self.chars(), false)
+    }
+
+    #[inline]
+    fn nfd_stream_safe(self) -> Decompositions<Chars<'a>> {
+        decompose::new_canonical(self.chars(), true)
     }
 
     #[inline]
     fn nfkd(self) -> Decompositions<Chars<'a>> {
-        decompose::new_compatible(self.chars())
+        decompose::new_compatible(self.chars(), false)
     }
 
     #[inline]
     fn nfc(self) -> Recompositions<Chars<'a>> {
-        recompose::new_canonical(self.chars())
+        recompose::new_canonical(self.chars(), false)
+    }
+
+    #[inline]
+    fn nfc_stream_safe(self) -> Recompositions<Chars<'a>> {
+        recompose::new_canonical(self.chars(), true)
     }
 
     #[inline]
     fn nfkc(self) -> Recompositions<Chars<'a>> {
-        recompose::new_compatible(self.chars())
+        recompose::new_compatible(self.chars(), false)
     }
 }
 
 impl<I: Iterator<Item=char>> UnicodeNormalization<I> for I {
     #[inline]
     fn nfd(self) -> Decompositions<I> {
-        decompose::new_canonical(self)
+        decompose::new_canonical(self, false)
+    }
+
+    #[inline]
+    fn nfd_stream_safe(self) -> Decompositions<I> {
+        decompose::new_canonical(self, true)
     }
 
     #[inline]
     fn nfkd(self) -> Decompositions<I> {
-        decompose::new_compatible(self)
+        decompose::new_compatible(self, false)
     }
 
     #[inline]
     fn nfc(self) -> Recompositions<I> {
-        recompose::new_canonical(self)
+        recompose::new_canonical(self, false)
+    }
+
+    #[inline]
+    fn nfc_stream_safe(self) -> Recompositions<I> {
+        recompose::new_canonical(self, true)
     }
 
     #[inline]
     fn nfkc(self) -> Recompositions<I> {
-        recompose::new_compatible(self)
+        recompose::new_compatible(self, false)
     }
 }

--- a/src/recompose.rs
+++ b/src/recompose.rs
@@ -21,7 +21,7 @@ enum RecompositionState {
 
 /// External iterator for a string recomposition's characters.
 #[derive(Clone)]
-pub struct Recompositions<I> {
+pub struct Recompositions<I: Iterator<Item=char>> {
     iter: Decompositions<I>,
     state: RecompositionState,
     buffer: VecDeque<char>,
@@ -30,9 +30,9 @@ pub struct Recompositions<I> {
 }
 
 #[inline]
-pub fn new_canonical<I: Iterator<Item=char>>(iter: I) -> Recompositions<I> {
+pub fn new_canonical<I: Iterator<Item=char>>(iter: I, stream_safe: bool) -> Recompositions<I> {
     Recompositions {
-        iter: super::decompose::new_canonical(iter),
+        iter: super::decompose::new_canonical(iter, stream_safe),
         state: self::RecompositionState::Composing,
         buffer: VecDeque::new(),
         composee: None,
@@ -41,9 +41,9 @@ pub fn new_canonical<I: Iterator<Item=char>>(iter: I) -> Recompositions<I> {
 }
 
 #[inline]
-pub fn new_compatible<I: Iterator<Item=char>>(iter: I) -> Recompositions<I> {
+pub fn new_compatible<I: Iterator<Item=char>>(iter: I, stream_safe: bool) -> Recompositions<I> {
     Recompositions {
-        iter: super::decompose::new_compatible(iter),
+        iter: super::decompose::new_compatible(iter, stream_safe),
         state : self::RecompositionState::Composing,
         buffer: VecDeque::new(),
         composee: None,

--- a/src/test.rs
+++ b/src/test.rs
@@ -13,6 +13,14 @@ use std::char;
 use super::UnicodeNormalization;
 use super::char::is_combining_mark;
 
+fn to_codepoint_seq(s: String) -> String {
+    s.chars().map(|c| format!("U+{:04X} ", c as u32)).collect::<String>()
+}
+macro_rules! assert_eq_strs {
+    ($left: expr, $right: expr) => {
+        assert_eq!(to_codepoint_seq($left.to_string()), to_codepoint_seq($right.to_string()));
+    }
+}
 
 #[test]
 fn test_nfd() {
@@ -34,6 +42,91 @@ fn test_nfd() {
     t!("\u{301}a", "\u{301}a");
     t!("\u{d4db}", "\u{1111}\u{1171}\u{11b6}");
     t!("\u{ac1c}", "\u{1100}\u{1162}");
+    t!("\u{E1}\u{325}\u{E1}\u{325}", "a\u{325}\u{301}a\u{325}\u{301}");
+    t!("\u{E1}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}",
+        "a\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}");
+    t!("\u{E1}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}",
+        "a\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}");
+}
+
+#[test]
+fn test_nfd_stream_safe() {
+    macro_rules! t {
+        ($input: expr, $expected: expr) => {
+            assert_eq_strs!($input.nfd_stream_safe().to_string(), $expected);
+            // A dummy iterator that is not std::str::Chars directly;
+            // note that `id_func` is used to ensure `Clone` implementation
+            assert_eq_strs!($input.chars().map(|c| c).nfd_stream_safe().collect::<String>(), $expected);
+        }
+    }
+    t!("abc", "abc");
+    t!("\u{1e0b}\u{1c4}", "d\u{307}\u{1c4}");
+    t!("\u{2026}", "\u{2026}");
+    t!("\u{2126}", "\u{3a9}");
+    t!("\u{1e0b}\u{323}", "d\u{323}\u{307}");
+    t!("\u{1e0d}\u{307}", "d\u{323}\u{307}");
+    t!("a\u{301}", "a\u{301}");
+    t!("\u{301}a", "\u{301}a");
+    t!("\u{d4db}", "\u{1111}\u{1171}\u{11b6}");
+    t!("\u{ac1c}", "\u{1100}\u{1162}");
+    t!("a\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}",
+        "a\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{34f}\
+        \u{301}\u{301}");
+    t!("\u{E1}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}",
+        "a\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{34f}\
+        \u{301}\u{301}");
+    t!("\u{E1}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}",
+        "a\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{34f}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{34f}\
+        \u{301}\u{301}");
 }
 
 #[test]
@@ -59,7 +152,9 @@ fn test_nfkd() {
 fn test_nfc() {
     macro_rules! t {
         ($input: expr, $expected: expr) => {
-            assert_eq!($input.nfc().to_string(), $expected);
+            assert_eq_strs!($input.nfc().to_string(), $expected);
+            //assert_eq!($input.nfc().map(|c| format!("U+{:04X},", c as u32)).collect::<String>(), $expected.chars().map(|c| format!("U+{:04X},", c as u32)).collect::<String>())
+            //assert_eq!($input.nfc().to_string(), $expected);
         }
     }
     t!("abc", "abc");
@@ -73,6 +168,53 @@ fn test_nfc() {
     t!("\u{d4db}", "\u{d4db}");
     t!("\u{ac1c}", "\u{ac1c}");
     t!("a\u{300}\u{305}\u{315}\u{5ae}b", "\u{e0}\u{5ae}\u{305}\u{315}b");
+    // U+0325 will get sorted to the front because it's CCC=220, and U+0301 is CCC=230, then it'll
+    // canonically combine with the a to make U+1E01.
+    t!("a\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{325}",
+        "\u{1E01}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}");
+}
+
+#[test]
+fn test_nfc_stream_safe() {
+    macro_rules! t {
+        ($input: expr, $expected: expr) => {
+            //assert_eq!($input.nfc_stream_safe().to_string(), $expected);
+            assert_eq!($input.nfc_stream_safe().map(|c| format!("U+{:04X},", c as u32)).collect::<String>(), $expected.chars().map(|c| format!("U+{:04X},", c as u32)).collect::<String>())
+        }
+    }
+    t!("abc", "abc");
+    t!("\u{1e0b}\u{1c4}", "\u{1e0b}\u{1c4}");
+    t!("\u{2026}", "\u{2026}");
+    t!("\u{2126}", "\u{3a9}");
+    t!("\u{1e0b}\u{323}", "\u{1e0d}\u{307}");
+    t!("\u{1e0d}\u{307}", "\u{1e0d}\u{307}");
+    t!("a\u{301}", "\u{e1}");
+    t!("\u{301}a", "\u{301}a");
+    t!("\u{d4db}", "\u{d4db}");
+    t!("\u{ac1c}", "\u{ac1c}");
+    t!("a\u{300}\u{305}\u{315}\u{5ae}b", "\u{e0}\u{5ae}\u{305}\u{315}b");
+    // In stream safe mode, COMBINING GRAPHEME JOINER (U+034F) will get inserted after 30 combining
+    // characters, which breaks up the sort/recombine so the U+0325 will not get sorted next to the
+    // a, so it'll combine with a U+0301 to U+00E1 instead.
+    t!("a\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{325}",
+        "\u{E1}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\u{301}\
+        \u{34F}\
+        \u{325}\u{301}\u{301}");
 }
 
 #[test]
@@ -111,11 +253,11 @@ fn test_official() {
             let r3 = normString!(nfc, s3);
             let r4 = normString!(nfc, s4);
             let r5 = normString!(nfc, s5);
-            assert_eq!(s2, &r1[..]);
-            assert_eq!(s2, &r2[..]);
-            assert_eq!(s2, &r3[..]);
-            assert_eq!(s4, &r4[..]);
-            assert_eq!(s4, &r5[..]);
+            assert_eq_strs!(s2, &r1[..]);
+            assert_eq_strs!(s2, &r2[..]);
+            assert_eq_strs!(s2, &r3[..]);
+            assert_eq_strs!(s4, &r4[..]);
+            assert_eq_strs!(s4, &r5[..]);
         }
 
         {
@@ -124,11 +266,11 @@ fn test_official() {
             let r3 = normString!(nfd, s3);
             let r4 = normString!(nfd, s4);
             let r5 = normString!(nfd, s5);
-            assert_eq!(s3, &r1[..]);
-            assert_eq!(s3, &r2[..]);
-            assert_eq!(s3, &r3[..]);
-            assert_eq!(s5, &r4[..]);
-            assert_eq!(s5, &r5[..]);
+            assert_eq_strs!(s3, &r1[..]);
+            assert_eq_strs!(s3, &r2[..]);
+            assert_eq_strs!(s3, &r3[..]);
+            assert_eq_strs!(s5, &r4[..]);
+            assert_eq_strs!(s5, &r5[..]);
         }
 
         {
@@ -137,11 +279,11 @@ fn test_official() {
             let r3 = normString!(nfkc, s3);
             let r4 = normString!(nfkc, s4);
             let r5 = normString!(nfkc, s5);
-            assert_eq!(s4, &r1[..]);
-            assert_eq!(s4, &r2[..]);
-            assert_eq!(s4, &r3[..]);
-            assert_eq!(s4, &r4[..]);
-            assert_eq!(s4, &r5[..]);
+            assert_eq_strs!(s4, &r1[..]);
+            assert_eq_strs!(s4, &r2[..]);
+            assert_eq_strs!(s4, &r3[..]);
+            assert_eq_strs!(s4, &r4[..]);
+            assert_eq_strs!(s4, &r5[..]);
         }
 
         {
@@ -150,11 +292,11 @@ fn test_official() {
             let r3 = normString!(nfkd, s3);
             let r4 = normString!(nfkd, s4);
             let r5 = normString!(nfkd, s5);
-            assert_eq!(s5, &r1[..]);
-            assert_eq!(s5, &r2[..]);
-            assert_eq!(s5, &r3[..]);
-            assert_eq!(s5, &r4[..]);
-            assert_eq!(s5, &r5[..]);
+            assert_eq_strs!(s5, &r1[..]);
+            assert_eq_strs!(s5, &r2[..]);
+            assert_eq_strs!(s5, &r3[..]);
+            assert_eq_strs!(s5, &r4[..]);
+            assert_eq_strs!(s5, &r5[..]);
         }
     }
 }


### PR DESCRIPTION
Adds `.nfc_stream_safe()` and `.nfd_stream_safe()`, which implement Stream-Safe Text Processing (http://unicode.org/reports/tr15/#UAX15-D4).

Essentially, it adds a `U+034F` (`COMBINING GRAPHEME JOINER`) after a sequence of 30 non-starter characters during decomposition. This puts a hard limit on the buffer size during decomposition, which also has the effect of limiting the size of canonical-ordering bubblesorts.

I specifically want this for parity with Go's [`x/text/unicode/norm`](https://godoc.org/golang.org/x/text/unicode/norm) package, which does this by default (with no other option.) We pass strings back and forth between these languages, and they need to agree on a normalization scheme.

I swapped to using a `Peekable` because it felt more natural to me to think about it in terms of lookahead (e.g. is the next character CCC=0? then we can sort and emit out of the buffer), but maybe it's less elegant/efficient to do this.