### PR TITLE
CI: Test on stable, nightly and 1.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,6 @@ sudo: false
 script:
   - cargo build --verbose
   - cargo test --verbose
-  - rustdoc --test README.md -L target/debug -L target/debug/deps
-  - cargo doc
-after_success: |
-  [ $TRAVIS_BRANCH = master ] &&
-  [ $TRAVIS_PULL_REQUEST = false ] &&
-  echo '<meta http-equiv=refresh content=0;url=unicode_normalization/index.html>' > target/doc/index.html &&
-  pip install ghp-import --user $USER &&
-  $HOME/.local/bin/ghp-import -n target/doc &&
-  git push -qf https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
-env:
-  global:
-    secure: Te91dtDN8uv5OBxVuMy+nvQ5GtnLU9r6amS9p6IbblVXyzXgXPQdFfAND+GXXfZNnsjAyS2LnZL4NcNOR4JF63H0KxTTDIGXLSUAmc0C98UhqWWvv5bjz4mY0YKs9MwuTBX9P0LdTZjvRTd+yJ2PYH7ORGen+ZuOmlPNE7lpzrg=
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: rust
+rust:
+  - 1.21.0
+  - stable
+  - nightly
 sudo: false
 script:
   - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["kwantam <kwantam@gmail.com>"]
 
 homepage = "https://github.com/unicode-rs/unicode-normalization"
 repository = "https://github.com/unicode-rs/unicode-normalization"
-documentation = "https://unicode-rs.github.io/unicode-normalization"
+documentation = "https://docs.rs/unicode-normalization/"
 
 license = "MIT/Apache-2.0"
 keywords = ["text", "unicode", "normalization", "decomposition", "recomposition"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
+# unicode-normalization
+
+[![Build Status](https://travis-ci.org/unicode-rs/unicode-normalization.svg)](https://travis-ci.org/unicode-rs/unicode-normalization)
+[![Docs](https://docs.rs/unicode-normalization/badge.svg)](https://docs.rs/unicode-normalization/)
+
 Unicode character composition and decomposition utilities
 as described in
 [Unicode Standard Annex #15](http://www.unicode.org/reports/tr15/).
-
-[![Build Status](https://travis-ci.org/unicode-rs/unicode-normalization.svg)](https://travis-ci.org/unicode-rs/unicode-normalization)
-
-[Documentation](https://unicode-rs.github.io/unicode-normalization/unicode_normalization/index.html)
 
 This crate requires Rust 1.21+.
 
@@ -23,7 +24,7 @@ fn main() {
 }
 ```
 
-# crates.io
+## crates.io
 
 You can use this package in your project by adding the following
 to your `Cargo.toml`:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ as described in
 
 [Documentation](https://unicode-rs.github.io/unicode-normalization/unicode_normalization/index.html)
 
+This crate requires Rust 1.21+.
+
 ```rust
 extern crate unicode_normalization;
 


### PR DESCRIPTION
- Add explicit tests on stable, nightly and 1.21.0
- Remove custom docs on github pages, link to docs.rs instead

As discussed at https://github.com/unicode-rs/unicode-normalization/issues/26#issuecomment-396643187.