### PR TITLE
Remove usage of smallvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,3 @@ Unicode Standard Annex #15.
 exclude = [ "target/*", "Cargo.lock", "scripts/tmp", "*.txt", "src/normalization_tests.rs", "src/test.rs" ]
 
 [dependencies]
-smallvec = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,6 @@
 #![doc(html_logo_url = "https://unicode-rs.github.io/unicode-rs_sm.png",
        html_favicon_url = "https://unicode-rs.github.io/unicode-rs_sm.png")]
 
-extern crate smallvec;
-
 pub use tables::UNICODE_VERSION;
 pub use decompose::Decompositions;
 pub use quick_check::{

--- a/src/recompose.rs
+++ b/src/recompose.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use decompose::Decompositions;
-use smallvec::SmallVec;
 use std::fmt::{self, Write};
 
 #[derive(Clone)]
@@ -24,7 +23,7 @@ enum RecompositionState {
 pub struct Recompositions<I> {
     iter: Decompositions<I>,
     state: RecompositionState,
-    buffer: SmallVec<[char; 4]>,
+    buffer: Vec<char>,
     composee: Option<char>,
     last_ccc: Option<u8>,
 }
@@ -34,7 +33,7 @@ pub fn new_canonical<I: Iterator<Item=char>>(iter: I) -> Recompositions<I> {
     Recompositions {
         iter: super::decompose::new_canonical(iter),
         state: self::RecompositionState::Composing,
-        buffer: SmallVec::new(),
+        buffer: Vec::with_capacity(4),
         composee: None,
         last_ccc: None,
     }
@@ -45,7 +44,7 @@ pub fn new_compatible<I: Iterator<Item=char>>(iter: I) -> Recompositions<I> {
     Recompositions {
         iter: super::decompose::new_compatible(iter),
         state: self::RecompositionState::Composing,
-        buffer: SmallVec::new(),
+        buffer: Vec::with_capacity(4),
         composee: None,
         last_ccc: None,
     }


### PR DESCRIPTION
Due to safety concerns, we are trying to eliminate use of `smallvec` from our dependencies, starting with the ones in critical paths handling user input.

`smallvec` contains a large amount of `unsafe`, probably contains [UB](https://github.com/servo/rust-smallvec/issues/126) that just happens to currently be working correctly, and has been the source of [several security vulnerabilities](https://github.com/RustSec/advisory-db/tree/master/crates/smallvec) in the past. For us, the use of this library in the context of unicode normalisation (which in our application is operating on user input) presents an unacceptable level of risk.

There is a performance regression from this change, which is acceptable in our application but may not be in others. If this performance regression is considered an unacceptable tradeoff for safety, then perhaps a feature could be used to enable/disable smallvec usage?

```
without smallvec:

running 22 tests
test bench_is_nfc_ascii                      ... bench:          17 ns/iter (+/- 2)
test bench_is_nfc_normalized                 ... bench:          29 ns/iter (+/- 3)
test bench_is_nfc_not_normalized             ... bench:         612 ns/iter (+/- 75)
test bench_is_nfc_stream_safe_ascii          ... bench:          17 ns/iter (+/- 2)
test bench_is_nfc_stream_safe_normalized     ... bench:          39 ns/iter (+/- 4)
test bench_is_nfc_stream_safe_not_normalized ... bench:         663 ns/iter (+/- 69)
test bench_is_nfd_ascii                      ... bench:          16 ns/iter (+/- 2)
test bench_is_nfd_normalized                 ... bench:          39 ns/iter (+/- 4)
test bench_is_nfd_not_normalized             ... bench:          15 ns/iter (+/- 1)
test bench_is_nfd_stream_safe_ascii          ... bench:          16 ns/iter (+/- 1)
test bench_is_nfd_stream_safe_normalized     ... bench:          49 ns/iter (+/- 6)
test bench_is_nfd_stream_safe_not_normalized ... bench:          15 ns/iter (+/- 1)
test bench_nfc_ascii                         ... bench:         612 ns/iter (+/- 67)
test bench_nfc_long                          ... bench:     190,220 ns/iter (+/- 47,039)
test bench_nfd_ascii                         ... bench:         414 ns/iter (+/- 78)
test bench_nfd_long                          ... bench:     130,626 ns/iter (+/- 19,313)
test bench_nfkc_ascii                        ... bench:         621 ns/iter (+/- 114)
test bench_nfkc_long                         ... bench:     206,319 ns/iter (+/- 11,866)
test bench_nfkd_ascii                        ... bench:         422 ns/iter (+/- 66)
test bench_nfkd_long                         ... bench:     142,023 ns/iter (+/- 12,416)
test bench_streamsafe_adversarial            ... bench:         391 ns/iter (+/- 30)
test bench_streamsafe_ascii                  ... bench:          74 ns/iter (+/- 9)

test result: ok. 0 passed; 0 failed; 0 ignored; 22 measured; 0 filtered out



with smallvec:

running 22 tests
test bench_is_nfc_ascii                      ... bench:          17 ns/iter (+/- 3)
test bench_is_nfc_normalized                 ... bench:          29 ns/iter (+/- 2)
test bench_is_nfc_not_normalized             ... bench:         348 ns/iter (+/- 46)
test bench_is_nfc_stream_safe_ascii          ... bench:          17 ns/iter (+/- 4)
test bench_is_nfc_stream_safe_normalized     ... bench:          39 ns/iter (+/- 3)
test bench_is_nfc_stream_safe_not_normalized ... bench:         393 ns/iter (+/- 39)
test bench_is_nfd_ascii                      ... bench:          16 ns/iter (+/- 1)
test bench_is_nfd_normalized                 ... bench:          40 ns/iter (+/- 8)
test bench_is_nfd_not_normalized             ... bench:          15 ns/iter (+/- 1)
test bench_is_nfd_stream_safe_ascii          ... bench:          16 ns/iter (+/- 2)
test bench_is_nfd_stream_safe_normalized     ... bench:          50 ns/iter (+/- 8)
test bench_is_nfd_stream_safe_not_normalized ... bench:          15 ns/iter (+/- 1)
test bench_nfc_ascii                         ... bench:         499 ns/iter (+/- 32)
test bench_nfc_long                          ... bench:     185,101 ns/iter (+/- 24,584)
test bench_nfd_ascii                         ... bench:         260 ns/iter (+/- 35)
test bench_nfd_long                          ... bench:     110,856 ns/iter (+/- 15,114)
test bench_nfkc_ascii                        ... bench:         493 ns/iter (+/- 82)
test bench_nfkc_long                         ... bench:     201,455 ns/iter (+/- 34,208)
test bench_nfkd_ascii                        ... bench:         284 ns/iter (+/- 67)
test bench_nfkd_long                         ... bench:     128,826 ns/iter (+/- 23,951)
test bench_streamsafe_adversarial            ... bench:         409 ns/iter (+/- 98)
test bench_streamsafe_ascii                  ... bench:          77 ns/iter (+/- 12)

test result: ok. 0 passed; 0 failed; 0 ignored; 22 measured; 0 filtered out
```