### PR TITLE
Allows ellipsis_inclusive_range_patterns

### DIFF
--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -119,6 +119,7 @@ pub(crate) fn hangul_decomposition_length(s: char) -> usize {
 // Compose a pair of Hangul Jamo
 #[allow(unsafe_code)]
 #[inline(always)]
+#[allow(ellipsis_inclusive_range_patterns)]
 fn compose_hangul(a: char, b: char) -> Option<char> {
     let (a, b) = (a as u32, b as u32);
     match (a, b) {

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -19217,6 +19217,7 @@ pub(crate) const COMBINING_MARK_KV: &[u32] = &[
 
 
 #[inline]
+#[allow(ellipsis_inclusive_range_patterns)]
 pub fn qc_nfc(c: char) -> IsNormalized {
     match c {
         '\u{0340}'...'\u{0341}' => No,
@@ -19340,6 +19341,7 @@ pub fn qc_nfc(c: char) -> IsNormalized {
 }
 
 #[inline]
+#[allow(ellipsis_inclusive_range_patterns)]
 pub fn qc_nfkc(c: char) -> IsNormalized {
     match c {
         '\u{00A0}' => No,
@@ -19776,6 +19778,7 @@ pub fn qc_nfkc(c: char) -> IsNormalized {
 }
 
 #[inline]
+#[allow(ellipsis_inclusive_range_patterns)]
 pub fn qc_nfd(c: char) -> IsNormalized {
     match c {
         '\u{00C0}'...'\u{00C5}' => No,
@@ -20025,6 +20028,7 @@ pub fn qc_nfd(c: char) -> IsNormalized {
 }
 
 #[inline]
+#[allow(ellipsis_inclusive_range_patterns)]
 pub fn qc_nfkd(c: char) -> IsNormalized {
     match c {
         '\u{00A0}' => No,


### PR DESCRIPTION
Refs: https://github.com/unicode-rs/unicode-normalization/issues/41

Warnings shown for `cargo build` in master: [cargo-build.txt](https://github.com/unicode-rs/unicode-normalization/files/3722220/cargo-build.txt)

No warnings in this PR:
```
   Compiling unicode-normalization v0.1.8 (/home/trivikr/workspace/unicode-normalization)
    Finished dev [unoptimized + debuginfo] target(s) in 0.57s
```