### PR TITLE
Rework tests for better consumer visibility.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ Decomposition and Recomposition, as described in
 Unicode Standard Annex #15.
 """
 
-exclude = [ "target/*", "Cargo.lock", "scripts/tmp", "*.txt", "src/normalization_tests.rs", "src/test.rs" ]
+exclude = [ "target/*", "Cargo.lock", "scripts/tmp", "*.txt", "src/normalization_tests.rs", "tests/normalization.rs" ]
 
 [dependencies]
 smallvec = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,11 +73,6 @@ mod quick_check;
 mod stream_safe;
 mod tables;
 
-#[cfg(test)]
-mod test;
-#[cfg(test)]
-mod normalization_tests;
-
 /// Methods for composing and decomposing characters.
 pub mod char {
     pub use normalize::{decompose_canonical, decompose_compatible, compose};
@@ -167,5 +162,35 @@ impl<I: Iterator<Item=char>> UnicodeNormalization<I> for I {
     #[inline]
     fn stream_safe(self) -> StreamSafe<I> {
         StreamSafe::new(self)
+    }
+}
+
+#[cfg(all(bloaty_test,test))]
+mod normalization_tests;
+
+mod tests {
+    #[cfg(bloaty_test)]
+    #[test]
+    fn test_quick_check() {
+        use normalization_tests::NORMALIZATION_TESTS;
+        use quick_check;
+        for test in NORMALIZATION_TESTS {
+            assert!(quick_check::is_nfc(test.nfc));
+            assert!(quick_check::is_nfd(test.nfd));
+            assert!(quick_check::is_nfkc(test.nfkc));
+            assert!(quick_check::is_nfkd(test.nfkd));
+            if test.nfc != test.nfd {
+                assert!(!quick_check::is_nfc(test.nfd));
+                assert!(!quick_check::is_nfd(test.nfc));
+            }
+            if test.nfkc != test.nfc {
+                assert!(!quick_check::is_nfkc(test.nfc));
+                assert!(quick_check::is_nfc(test.nfkc));
+            }
+            if test.nfkd != test.nfd {
+                assert!(!quick_check::is_nfkd(test.nfd));
+                assert!(quick_check::is_nfd(test.nfkd));
+            }
+        }
     }
 }

--- a/src/stream_safe.rs
+++ b/src/stream_safe.rs
@@ -111,6 +111,7 @@ mod tests {
         classify_nonstarters,
     };
     use std::char;
+    #[cfg(bloaty_test)]
     use normalization_tests::NORMALIZATION_TESTS;
     use normalize::decompose_compatible;
     use lookups::canonical_combining_class;
@@ -119,6 +120,7 @@ mod tests {
         StreamSafe::new(s.chars()).collect()
     }
 
+    #[cfg(bloaty_test)]
     #[test]
     fn test_normalization_tests_unaffected() {
         for test in NORMALIZATION_TESTS {

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+extern crate unicode_normalization;
 
 use std::char;
-use super::UnicodeNormalization;
-use super::char::is_combining_mark;
-
+use unicode_normalization::UnicodeNormalization;
+use unicode_normalization::char::is_combining_mark;
 
 #[test]
 fn test_nfd() {
@@ -95,93 +95,6 @@ fn test_nfkc() {
     t!("a\u{300}\u{305}\u{315}\u{5ae}b", "\u{e0}\u{5ae}\u{305}\u{315}b");
 }
 
-#[test]
-fn test_official() {
-    use normalization_tests::NORMALIZATION_TESTS;
-    macro_rules! normString {
-        ($method: ident, $input: expr) => { $input.$method().collect::<String>() }
-    }
-
-    for test in NORMALIZATION_TESTS {
-        // these invariants come from the CONFORMANCE section of
-        // http://www.unicode.org/Public/UNIDATA/NormalizationTest.txt
-        {
-            let r1 = normString!(nfc, test.source);
-            let r2 = normString!(nfc, test.nfc);
-            let r3 = normString!(nfc, test.nfd);
-            let r4 = normString!(nfc, test.nfkc);
-            let r5 = normString!(nfc, test.nfkd);
-            assert_eq!(test.nfc, &r1[..]);
-            assert_eq!(test.nfc, &r2[..]);
-            assert_eq!(test.nfc, &r3[..]);
-            assert_eq!(test.nfkc, &r4[..]);
-            assert_eq!(test.nfkc, &r5[..]);
-        }
-
-        {
-            let r1 = normString!(nfd, test.source);
-            let r2 = normString!(nfd, test.nfc);
-            let r3 = normString!(nfd, test.nfd);
-            let r4 = normString!(nfd, test.nfkc);
-            let r5 = normString!(nfd, test.nfkd);
-            assert_eq!(test.nfd, &r1[..]);
-            assert_eq!(test.nfd, &r2[..]);
-            assert_eq!(test.nfd, &r3[..]);
-            assert_eq!(test.nfkd, &r4[..]);
-            assert_eq!(test.nfkd, &r5[..]);
-        }
-
-        {
-            let r1 = normString!(nfkc, test.source);
-            let r2 = normString!(nfkc, test.nfc);
-            let r3 = normString!(nfkc, test.nfd);
-            let r4 = normString!(nfkc, test.nfkc);
-            let r5 = normString!(nfkc, test.nfkd);
-            assert_eq!(test.nfkc, &r1[..]);
-            assert_eq!(test.nfkc, &r2[..]);
-            assert_eq!(test.nfkc, &r3[..]);
-            assert_eq!(test.nfkc, &r4[..]);
-            assert_eq!(test.nfkc, &r5[..]);
-        }
-
-        {
-            let r1 = normString!(nfkd, test.source);
-            let r2 = normString!(nfkd, test.nfc);
-            let r3 = normString!(nfkd, test.nfd);
-            let r4 = normString!(nfkd, test.nfkc);
-            let r5 = normString!(nfkd, test.nfkd);
-            assert_eq!(test.nfkd, &r1[..]);
-            assert_eq!(test.nfkd, &r2[..]);
-            assert_eq!(test.nfkd, &r3[..]);
-            assert_eq!(test.nfkd, &r4[..]);
-            assert_eq!(test.nfkd, &r5[..]);
-        }
-    }
-}
-
-#[test]
-fn test_quick_check() {
-    use normalization_tests::NORMALIZATION_TESTS;
-    use quick_check;
-    for test in NORMALIZATION_TESTS {
-        assert!(quick_check::is_nfc(test.nfc));
-        assert!(quick_check::is_nfd(test.nfd));
-        assert!(quick_check::is_nfkc(test.nfkc));
-        assert!(quick_check::is_nfkd(test.nfkd));
-        if test.nfc != test.nfd {
-            assert!(!quick_check::is_nfc(test.nfd));
-            assert!(!quick_check::is_nfd(test.nfc));
-        }
-        if test.nfkc != test.nfc {
-            assert!(!quick_check::is_nfkc(test.nfc));
-            assert!(quick_check::is_nfc(test.nfkc));
-        }
-        if test.nfkd != test.nfd {
-            assert!(!quick_check::is_nfkd(test.nfd));
-            assert!(quick_check::is_nfd(test.nfkd));
-        }
-    }
-}
 
 #[test]
 fn test_is_combining_mark_ascii() {

--- a/tests/normalization.rs
+++ b/tests/normalization.rs
@@ -1,0 +1,72 @@
+extern crate unicode_normalization;
+#[cfg(bloaty_test)]
+#[path = "../src/normalization_tests.rs"]
+mod normalization_tests;
+#[cfg(bloaty_test)]
+use unicode_normalization::UnicodeNormalization;
+
+#[cfg(bloaty_test)]
+#[test]
+fn test_official() {
+    use normalization_tests::NORMALIZATION_TESTS;
+    macro_rules! normString {
+        ($method: ident, $input: expr) => { $input.$method().collect::<String>() }
+    }
+
+    for test in NORMALIZATION_TESTS {
+        // these invariants come from the CONFORMANCE section of
+        // http://www.unicode.org/Public/UNIDATA/NormalizationTest.txt
+        {
+            let r1 = normString!(nfc, test.source);
+            let r2 = normString!(nfc, test.nfc);
+            let r3 = normString!(nfc, test.nfd);
+            let r4 = normString!(nfc, test.nfkc);
+            let r5 = normString!(nfc, test.nfkd);
+            assert_eq!(test.nfc, &r1[..]);
+            assert_eq!(test.nfc, &r2[..]);
+            assert_eq!(test.nfc, &r3[..]);
+            assert_eq!(test.nfkc, &r4[..]);
+            assert_eq!(test.nfkc, &r5[..]);
+        }
+
+        {
+            let r1 = normString!(nfd, test.source);
+            let r2 = normString!(nfd, test.nfc);
+            let r3 = normString!(nfd, test.nfd);
+            let r4 = normString!(nfd, test.nfkc);
+            let r5 = normString!(nfd, test.nfkd);
+            assert_eq!(test.nfd, &r1[..]);
+            assert_eq!(test.nfd, &r2[..]);
+            assert_eq!(test.nfd, &r3[..]);
+            assert_eq!(test.nfkd, &r4[..]);
+            assert_eq!(test.nfkd, &r5[..]);
+        }
+
+        {
+            let r1 = normString!(nfkc, test.source);
+            let r2 = normString!(nfkc, test.nfc);
+            let r3 = normString!(nfkc, test.nfd);
+            let r4 = normString!(nfkc, test.nfkc);
+            let r5 = normString!(nfkc, test.nfkd);
+            assert_eq!(test.nfkc, &r1[..]);
+            assert_eq!(test.nfkc, &r2[..]);
+            assert_eq!(test.nfkc, &r3[..]);
+            assert_eq!(test.nfkc, &r4[..]);
+            assert_eq!(test.nfkc, &r5[..]);
+        }
+
+        {
+            let r1 = normString!(nfkd, test.source);
+            let r2 = normString!(nfkd, test.nfc);
+            let r3 = normString!(nfkd, test.nfd);
+            let r4 = normString!(nfkd, test.nfkc);
+            let r5 = normString!(nfkd, test.nfkd);
+            assert_eq!(test.nfkd, &r1[..]);
+            assert_eq!(test.nfkd, &r2[..]);
+            assert_eq!(test.nfkd, &r3[..]);
+            assert_eq!(test.nfkd, &r4[..]);
+            assert_eq!(test.nfkd, &r5[..]);
+        }
+    }
+}
+


### PR DESCRIPTION
This patch moves as many tests as viable to tests/, in order to make
nuking "non-critical" code easier.

( Nothing will hurt if you nuke tests/*, just you won't have as many
  tests )

All tests that require src/normalization_tests.rs are gated by

```rust
  #[cfg(bloaty_test)]
```

So that they only run when invoked as:

  RUSTFLAGS="--cfg bloaty_test" cargo test

If you do this, its your reponsibility to make sure that file is there.

This means nuking src/normalization_tests.rs doesn't break what happens
by default when a consumer runs `cargo test` in a published crate.

One tests that previously lived in its own file was folded back
into src/lib.rs, because it was more concise that way, and after the
migration to tests/,  it was pretty much there on its own, not
warranting an individual file.

Closes: #38 