### PR TITLE
Add "opt-out" test gating for vendors, document getting working tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ sudo: false
 script:
   - cargo build --verbose
   - cargo test --verbose
+  - cargo package
+  - cd target/package/unicode-normalization-*
+  - RUSTFLAGS="--cfg minimal_tests" cargo test --verbose
 notifications:
   email:
     on_success: never

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ Decomposition and Recomposition, as described in
 Unicode Standard Annex #15.
 """
 
-exclude = [ "target/*", "Cargo.lock", "scripts/tmp", "*.txt", "src/normalization_tests.rs", "src/test.rs" ]
+exclude = [ "target/*", "Cargo.lock", "scripts/tmp", "*.txt", "src/normalization_tests.rs" ]
 
 [dependencies]
 smallvec = "0.6"

--- a/README.md
+++ b/README.md
@@ -33,3 +33,26 @@ to your `Cargo.toml`:
 [dependencies]
 unicode-normalization = "0.1.8"
 ```
+
+## Linux Vendors / Downstream
+As is, tests won't work on the published crate, as important
+corpus data required for fully testing functionality otherwise
+bloats the size of the crate.
+
+Tests aren't hugely meaningful without this, but there are two
+workarounds:
+
+```bash
+RUSTFLAGS="--cfg minimal_tests" cargo test
+```
+
+This will make the crate compile, and some arbitrary set of lower
+quality tests pass.
+
+```bash
+python scripts/unicode.py
+cp ./normalization_tests.rs src/
+```
+
+This will generate the full corpus required for tests to work,
+without needing to pass any special flags.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ mod tables;
 
 #[cfg(test)]
 mod test;
-#[cfg(test)]
+#[cfg(all(test,not(minimal_tests)))]
 mod normalization_tests;
 
 /// Methods for composing and decomposing characters.

--- a/src/stream_safe.rs
+++ b/src/stream_safe.rs
@@ -111,6 +111,7 @@ mod tests {
         classify_nonstarters,
     };
     use std::char;
+    #[cfg(not(minimal_tests))]
     use normalization_tests::NORMALIZATION_TESTS;
     use normalize::decompose_compatible;
     use lookups::canonical_combining_class;
@@ -119,6 +120,7 @@ mod tests {
         StreamSafe::new(s.chars()).collect()
     }
 
+    #[cfg(not(minimal_tests))]
     #[test]
     fn test_normalization_tests_unaffected() {
         for test in NORMALIZATION_TESTS {

--- a/src/test.rs
+++ b/src/test.rs
@@ -95,6 +95,7 @@ fn test_nfkc() {
     t!("a\u{300}\u{305}\u{315}\u{5ae}b", "\u{e0}\u{5ae}\u{305}\u{315}b");
 }
 
+#[cfg(not(minimal_tests))]
 #[test]
 fn test_official() {
     use normalization_tests::NORMALIZATION_TESTS;
@@ -158,7 +159,7 @@ fn test_official() {
         }
     }
 }
-
+#[cfg(not(minimal_tests))]
 #[test]
 fn test_quick_check() {
     use normalization_tests::NORMALIZATION_TESTS;


### PR DESCRIPTION
Hopefully this provides the best of all worlds.

Importantly, this re-introduces src/test.rs, as that's something that
can't be trivially generated.

Both approaches are documented so the path to the easiest working
solution is clear for vendors, and they can pick either the more
expensive solution, or the simpler (but less comprehensive) one.

If this PR meets general approval, I'd like to add a .travis.yml
step that automatically tests the --cfg minimal_tests path, so at
least, that will be a "stable" target, as testing that the deployed
crate is free from errors is presently too much work to expect the
average maintainer or contributor to remember to do.

Closes: https://github.com/unicode-rs/unicode-normalization/issues/38