### PR TITLE
Switch from SmallVec to 100% safe TinyVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ Unicode Standard Annex #15.
 
 exclude = [ "target/*", "Cargo.lock", "scripts/tmp", "*.txt", "tests/*" ]
 
-[dependencies]
-tinyvec = "0.1.2"
+[dependencies.tinyvec]
+version = "0.3.2"
+features = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ Unicode Standard Annex #15.
 exclude = [ "target/*", "Cargo.lock", "scripts/tmp", "*.txt", "tests/*" ]
 
 [dependencies]
-smallvec = "1.0"
+tinyvec = "0.1.2"

--- a/src/decompose.rs
+++ b/src/decompose.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use smallvec::SmallVec;
+use tinyvec::TinyVec;
 use std::fmt::{self, Write};
 use std::iter::Fuse;
 use std::ops::Range;
@@ -32,7 +32,7 @@ pub struct Decompositions<I> {
     // 2) "Ready" characters which are sorted and ready to emit on demand;
     // 3) A "pending" block which stills needs more characters for us to be able
     //    to sort in canonical order and is not safe to emit.
-    buffer: SmallVec<[(u8, char); 4]>,
+    buffer: TinyVec<[(u8, char); 4]>,
     ready: Range<usize>,
 }
 
@@ -41,7 +41,7 @@ pub fn new_canonical<I: Iterator<Item=char>>(iter: I) -> Decompositions<I> {
     Decompositions {
         kind: self::DecompositionType::Canonical,
         iter: iter.fuse(),
-        buffer: SmallVec::new(),
+        buffer: TinyVec::new(),
         ready: 0..0,
     }
 }
@@ -51,7 +51,7 @@ pub fn new_compatible<I: Iterator<Item=char>>(iter: I) -> Decompositions<I> {
     Decompositions {
         kind: self::DecompositionType::Compatible,
         iter: iter.fuse(),
-        buffer: SmallVec::new(),
+        buffer: TinyVec::new(),
         ready: 0..0,
     }
 }

--- a/src/decompose.rs
+++ b/src/decompose.rs
@@ -78,8 +78,8 @@ impl<I> Decompositions<I> {
 
     #[inline]
     fn reset_buffer(&mut self) {
-        // Equivalent to `self.buffer.drain(0..self.ready.end)` (if SmallVec
-        // supported this API)
+        // Equivalent to `self.buffer.drain(0..self.ready.end)`
+        // but faster than drain() if the buffer is a SmallVec or TinyVec
         let pending = self.buffer.len() - self.ready.end;
         for i in 0..pending {
             self.buffer[i] = self.buffer[i + self.ready.end];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 #![doc(html_logo_url = "https://unicode-rs.github.io/unicode-rs_sm.png",
        html_favicon_url = "https://unicode-rs.github.io/unicode-rs_sm.png")]
 
-extern crate smallvec;
+extern crate tinyvec;
 
 pub use tables::UNICODE_VERSION;
 pub use decompose::Decompositions;

--- a/src/recompose.rs
+++ b/src/recompose.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use decompose::Decompositions;
-use smallvec::SmallVec;
+use tinyvec::TinyVec;
 use std::fmt::{self, Write};
 
 #[derive(Clone)]
@@ -24,7 +24,7 @@ enum RecompositionState {
 pub struct Recompositions<I> {
     iter: Decompositions<I>,
     state: RecompositionState,
-    buffer: SmallVec<[char; 4]>,
+    buffer: TinyVec<[char; 4]>,
     composee: Option<char>,
     last_ccc: Option<u8>,
 }
@@ -34,7 +34,7 @@ pub fn new_canonical<I: Iterator<Item=char>>(iter: I) -> Recompositions<I> {
     Recompositions {
         iter: super::decompose::new_canonical(iter),
         state: self::RecompositionState::Composing,
-        buffer: SmallVec::new(),
+        buffer: TinyVec::new(),
         composee: None,
         last_ccc: None,
     }
@@ -45,7 +45,7 @@ pub fn new_compatible<I: Iterator<Item=char>>(iter: I) -> Recompositions<I> {
     Recompositions {
         iter: super::decompose::new_compatible(iter),
         state: self::RecompositionState::Composing,
-        buffer: SmallVec::new(),
+        buffer: TinyVec::new(),
         composee: None,
         last_ccc: None,
     }


### PR DESCRIPTION
Replaces uses of SmallVec with [TinyVec](https://github.com/Lokathor/tinyvec), which is the same idea implemented in 100% safe code.

Performance is generally in line with SmallVec in this case, with some benchmarks being slightly slower and some slightly faster:

SmallVec 1.1.0
```
test bench_is_nfc_ascii                      ... bench:          15 ns/iter (+/- 0)
test bench_is_nfc_normalized                 ... bench:          26 ns/iter (+/- 0)
test bench_is_nfc_not_normalized             ... bench:         455 ns/iter (+/- 7)
test bench_is_nfc_stream_safe_ascii          ... bench:          14 ns/iter (+/- 0)
test bench_is_nfc_stream_safe_normalized     ... bench:          39 ns/iter (+/- 0)
test bench_is_nfc_stream_safe_not_normalized ... bench:         526 ns/iter (+/- 9)
test bench_is_nfd_ascii                      ... bench:          17 ns/iter (+/- 3)
test bench_is_nfd_normalized                 ... bench:          43 ns/iter (+/- 0)
test bench_is_nfd_not_normalized             ... bench:          15 ns/iter (+/- 0)
test bench_is_nfd_stream_safe_ascii          ... bench:          17 ns/iter (+/- 3)
test bench_is_nfd_stream_safe_normalized     ... bench:          72 ns/iter (+/- 1)
test bench_is_nfd_stream_safe_not_normalized ... bench:          15 ns/iter (+/- 0)
test bench_nfc_ascii                         ... bench:         557 ns/iter (+/- 6)
test bench_nfc_long                          ... bench:     235,422 ns/iter (+/- 2,928)
test bench_nfd_ascii                         ... bench:         325 ns/iter (+/- 6)
test bench_nfd_long                          ... bench:     133,196 ns/iter (+/- 1,167)
test bench_nfkc_ascii                        ... bench:         557 ns/iter (+/- 19)
test bench_nfkc_long                         ... bench:     252,428 ns/iter (+/- 2,076)
test bench_nfkd_ascii                        ... bench:         300 ns/iter (+/- 3)
test bench_nfkd_long                         ... bench:     137,857 ns/iter (+/- 1,435)
test bench_streamsafe_adversarial            ... bench:         471 ns/iter (+/- 7)
test bench_streamsafe_ascii                  ... bench:          81 ns/iter (+/- 1)
```

TinyVec 0.3.2
```
test bench_is_nfc_ascii                      ... bench:          14 ns/iter (+/- 0)
test bench_is_nfc_normalized                 ... bench:          26 ns/iter (+/- 0)
test bench_is_nfc_not_normalized             ... bench:         440 ns/iter (+/- 3)
test bench_is_nfc_stream_safe_ascii          ... bench:          14 ns/iter (+/- 0)
test bench_is_nfc_stream_safe_normalized     ... bench:          38 ns/iter (+/- 0)
test bench_is_nfc_stream_safe_not_normalized ... bench:         524 ns/iter (+/- 5)
test bench_is_nfd_ascii                      ... bench:          16 ns/iter (+/- 2)
test bench_is_nfd_normalized                 ... bench:          42 ns/iter (+/- 0)
test bench_is_nfd_not_normalized             ... bench:          14 ns/iter (+/- 0)
test bench_is_nfd_stream_safe_ascii          ... bench:          16 ns/iter (+/- 0)
test bench_is_nfd_stream_safe_normalized     ... bench:          53 ns/iter (+/- 0)
test bench_is_nfd_stream_safe_not_normalized ... bench:          15 ns/iter (+/- 0)
test bench_nfc_ascii                         ... bench:         595 ns/iter (+/- 8)
test bench_nfc_long                          ... bench:     216,145 ns/iter (+/- 3,176)
test bench_nfd_ascii                         ... bench:         361 ns/iter (+/- 5)
test bench_nfd_long                          ... bench:     141,053 ns/iter (+/- 552)
test bench_nfkc_ascii                        ... bench:         587 ns/iter (+/- 8)
test bench_nfkc_long                         ... bench:     225,678 ns/iter (+/- 2,640)
test bench_nfkd_ascii                        ... bench:         333 ns/iter (+/- 7)
test bench_nfkd_long                         ... bench:     149,023 ns/iter (+/- 613)
test bench_streamsafe_adversarial            ... bench:         485 ns/iter (+/- 2)
test bench_streamsafe_ascii                  ... bench:          68 ns/iter (+/- 0)
```

As you can see, e.g. `bench_is_nfd_stream_safe_normalized` and `bench_nfkc_long` have improved while `bench_nfkd_long` and `bench_nfc_ascii` have regressed, but none of the changes are dramatic.

`cargo test` passes, I haven't run any parametric or fuzz testing (not sure if this crate has any). TinyVec itself has been fuzz-tested for equivalence to `std::Vec` using [arbitrary-model-tests](https://github.com/jakubadamw/arbitrary-model-tests) framework.