### PR TITLE
Correctly reset streamsafe iterator

### DIFF
--- a/src/stream_safe.rs
+++ b/src/stream_safe.rs
@@ -42,7 +42,7 @@ impl<I: Iterator<Item = char>> Iterator for StreamSafe<I> {
         let d = classify_nonstarters(next_ch);
         if self.nonstarter_count + d.leading_nonstarters > MAX_NONSTARTERS {
             self.buffer = Some(next_ch);
-            self.nonstarter_count = 0;
+            self.nonstarter_count += d.decomposition_len;
             return Some(COMBINING_GRAPHEME_JOINER);
         }
 

--- a/tests/test_streamsafe_regression.rs
+++ b/tests/test_streamsafe_regression.rs
@@ -1,0 +1,14 @@
+use unicode_normalization::{
+    char::canonical_combining_class, is_nfc, is_nfc_stream_safe, UnicodeNormalization,
+};
+
+#[test]
+fn test_streamsafe_regression(){
+    let input = "\u{342}".repeat(55) + &"\u{344}".repeat(3);
+    let nfc_ss = input.chars().nfc().stream_safe().collect::<String>();
+
+    // The result should be NFC:
+    assert!(is_nfc(&nfc_ss));
+    // and should be stream-safe:
+    assert!(is_nfc_stream_safe(&nfc_ss))
+}


### PR DESCRIPTION
The attached test was failing otherwise, (credit @sunfishcode). We basically did not take into account the decomposition width of the next character when buffering after a combining grapheme joiner.

We should probably add fuzz targets for this stuff using `cargo-fuzz`.