### PR TITLE
Add a fuzz target.

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,2 @@
+artifacts
+corpus

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "unicode-normalization-fuzz"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3.2"
+unicode-normalization = "0.1.15"
+
+[[bin]]
+name = "unicode-normalization"
+path = "fuzz_targets/unicode-normalization.rs"
+test = false
+doc = false
+
+# Work around https://github.com/rust-lang/cargo/issues/8338
+[workspace]

--- a/fuzz/fuzz_targets/unicode-normalization.rs
+++ b/fuzz/fuzz_targets/unicode-normalization.rs
@@ -1,0 +1,71 @@
+#![no_main]
+
+#[macro_use]
+extern crate libfuzzer_sys;
+
+use unicode_normalization::{
+    is_nfc, is_nfc_quick, is_nfc_stream_safe, is_nfc_stream_safe_quick, is_nfd, is_nfd_quick,
+    is_nfd_stream_safe, is_nfd_stream_safe_quick, is_nfkc, is_nfkc_quick, is_nfkd, is_nfkd_quick,
+    IsNormalized, UnicodeNormalization,
+};
+
+fn from_bool(is_normalized: bool) -> IsNormalized {
+    if is_normalized {
+        IsNormalized::Yes
+    } else {
+        IsNormalized::No
+    }
+}
+
+fuzz_target!(|input: String| {
+    // The full predicates imply the quick predicates.
+    assert!(is_nfc_quick(input.chars()) != from_bool(!is_nfc(&input)));
+    assert!(is_nfd_quick(input.chars()) != from_bool(!is_nfd(&input)));
+    assert!(is_nfkc_quick(input.chars()) != from_bool(!is_nfkc(&input)));
+    assert!(is_nfkd_quick(input.chars()) != from_bool(!is_nfkd(&input)));
+    assert!(is_nfc_stream_safe_quick(input.chars()) != from_bool(!is_nfc_stream_safe(&input)));
+    assert!(is_nfd_stream_safe_quick(input.chars()) != from_bool(!is_nfd_stream_safe(&input)));
+
+    // Check NFC, NFD, NFKC, and NFKD normalization.
+    let nfc = input.chars().nfc().collect::<String>();
+    assert_eq!(nfc.is_empty(), input.is_empty());
+    assert_ne!(is_nfc_quick(nfc.chars()), IsNormalized::No);
+    assert!(is_nfc(&nfc));
+
+    let nfd = input.chars().nfd().collect::<String>();
+    assert!(nfd.len() >= nfc.len());
+    assert_ne!(is_nfd_quick(nfd.chars()), IsNormalized::No);
+    assert!(is_nfd(&nfd));
+
+    let nfkc = input.chars().nfkc().collect::<String>();
+    assert_eq!(nfkc.is_empty(), input.is_empty());
+    assert_ne!(is_nfkc_quick(nfkc.chars()), IsNormalized::No);
+    assert!(is_nfkc(&nfkc));
+
+    let nfkd = input.chars().nfkd().collect::<String>();
+    assert!(nfkd.len() >= nfkc.len());
+    assert_ne!(is_nfkd_quick(nfkd.chars()), IsNormalized::No);
+    assert!(is_nfkd(&nfkd));
+
+    // Check stream-safe.
+    let nfc_ss = nfc.chars().stream_safe().collect::<String>();
+    assert!(nfc_ss.len() >= nfc.len());
+    assert_ne!(is_nfc_stream_safe_quick(nfc_ss.chars()), IsNormalized::No);
+    assert!(is_nfc_stream_safe(&nfc_ss));
+
+    let nfd_ss = nfd.chars().stream_safe().collect::<String>();
+    assert!(nfd_ss.len() >= nfd.len());
+    assert_ne!(is_nfd_stream_safe_quick(nfd_ss.chars()), IsNormalized::No);
+    assert!(is_nfd_stream_safe(&nfd_ss));
+
+    // Check that NFC and NFD preserve stream-safe.
+    let ss_nfc = input.chars().stream_safe().nfc().collect::<String>();
+    assert_eq!(ss_nfc.is_empty(), input.is_empty());
+    assert_ne!(is_nfc_stream_safe_quick(ss_nfc.chars()), IsNormalized::No);
+    assert!(is_nfc_stream_safe(&ss_nfc));
+
+    let ss_nfd = input.chars().stream_safe().nfd().collect::<String>();
+    assert_eq!(ss_nfd.is_empty(), input.is_empty());
+    assert_ne!(is_nfd_stream_safe_quick(ss_nfd.chars()), IsNormalized::No);
+    assert!(is_nfd_stream_safe(&ss_nfd));
+});


### PR DESCRIPTION
Here's a fuzz target which checks all the crate's iterators against its predicates. I ran it briefly with 0.1.15 and didn't see any failures.
