### PR TITLE
Make the decompose iterator avoid buffering elements past a starter.

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,5 +17,11 @@ path = "fuzz_targets/unicode-normalization.rs"
 test = false
 doc = false
 
+[[bin]]
+name = "streaming"
+path = "fuzz_targets/streaming.rs"
+test = false
+doc = false
+
 # Work around https://github.com/rust-lang/cargo/issues/8338
 [workspace]

--- a/fuzz/fuzz_targets/streaming.rs
+++ b/fuzz/fuzz_targets/streaming.rs
@@ -1,0 +1,49 @@
+//! Test that the NFC iterator doesn't run needlessly further ahead of its
+//! underlying iterator.
+//!
+//! The NFC iterator is wrapped around the NFD iterator, and it buffers
+//! up combining characters so that it can sort them once it knows it has
+//! seen the complete sequence. At that point, it should drain its own
+//! buffer before consuming more characters from its inner iterator.
+//! This fuzz target defines a custom iterator which records how many
+//! times it's called so we can detect if NFC called it too many times.
+
+#![no_main]
+
+#[macro_use]
+extern crate libfuzzer_sys;
+
+use std::str::Chars;
+use std::cell::RefCell;
+use std::rc::Rc;
+use unicode_normalization::UnicodeNormalization;
+
+const MAX_NONSTARTERS: u32 = 30;
+
+#[derive(Debug)]
+struct Counter<'a> {
+    iter: Chars<'a>,
+    value: Rc<RefCell<u32>>,
+}
+
+impl<'a> Iterator for Counter<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<char> {
+        *self.value.borrow_mut() += 1;
+        self.iter.next()
+    }
+}
+
+fuzz_target!(|input: String| {
+    let stream_safe = input.chars().stream_safe().collect::<String>();
+
+    let mut value = Rc::new(RefCell::new(0));
+    let counter = Counter { iter: stream_safe.chars(), value: Rc::clone(&mut value) };
+    for _ in counter.nfc() {
+        // Plus 2: one for the starter at the beginning of a sequence, and
+        // one for a starter that begins the following sequence.
+        assert!(*value.borrow() <= MAX_NONSTARTERS + 2);
+        *value.borrow_mut() = 0;
+    }
+});

--- a/src/decompose.rs
+++ b/src/decompose.rs
@@ -63,9 +63,11 @@ impl<I> Decompositions<I> {
 
         if class == 0 {
             self.sort_pending();
+            self.buffer.push((class, ch));
+            self.ready.end = self.buffer.len();
+        } else {
+            self.buffer.push((class, ch));
         }
-
-        self.buffer.push((class, ch));
     }
 
     #[inline]
@@ -73,7 +75,6 @@ impl<I> Decompositions<I> {
         // NB: `sort_by_key` is stable, so it will preserve the original text's
         // order within a combining class.
         self.buffer[self.ready.end..].sort_by_key(|k| k.0);
-        self.ready.end = self.buffer.len();
     }
 
     #[inline]
@@ -117,6 +118,7 @@ impl<I: Iterator<Item = char>> Iterator for Decompositions<I> {
                         return None;
                     } else {
                         self.sort_pending();
+                        self.ready.end = self.buffer.len();
 
                         // This implementation means that we can call `next`
                         // on an exhausted iterator; the last outer `next` call


### PR DESCRIPTION
Once the decompose iterator sees a starter, it should immediately start
returning characters from the preceeding sequence. If the input happens
to be stream-safe, it should never get more than MAX_NONSTARTERS + plus
boundary values ahead of its inner iterator.
