### PR TITLE
Minor cleanups after #63

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3.2"
-unicode-normalization = "0.1.15"
+libfuzzer-sys = "0.3.4"
+unicode-normalization = { path = ".." }
 
 [[bin]]
 name = "unicode-normalization"

--- a/fuzz/fuzz_targets/unicode-normalization.rs
+++ b/fuzz/fuzz_targets/unicode-normalization.rs
@@ -19,12 +19,18 @@ fn from_bool(is_normalized: bool) -> IsNormalized {
 
 fuzz_target!(|input: String| {
     // The full predicates imply the quick predicates.
-    assert!(is_nfc_quick(input.chars()) != from_bool(!is_nfc(&input)));
-    assert!(is_nfd_quick(input.chars()) != from_bool(!is_nfd(&input)));
-    assert!(is_nfkc_quick(input.chars()) != from_bool(!is_nfkc(&input)));
-    assert!(is_nfkd_quick(input.chars()) != from_bool(!is_nfkd(&input)));
-    assert!(is_nfc_stream_safe_quick(input.chars()) != from_bool(!is_nfc_stream_safe(&input)));
-    assert!(is_nfd_stream_safe_quick(input.chars()) != from_bool(!is_nfd_stream_safe(&input)));
+    assert_ne!(is_nfc_quick(input.chars()), from_bool(!is_nfc(&input)));
+    assert_ne!(is_nfd_quick(input.chars()), from_bool(!is_nfd(&input)));
+    assert_ne!(is_nfkc_quick(input.chars()), from_bool(!is_nfkc(&input)));
+    assert_ne!(is_nfkd_quick(input.chars()), from_bool(!is_nfkd(&input)));
+    assert_ne!(
+        is_nfc_stream_safe_quick(input.chars()),
+        from_bool(!is_nfc_stream_safe(&input))
+    );
+    assert_ne!(
+        is_nfd_stream_safe_quick(input.chars()),
+        from_bool(!is_nfd_stream_safe(&input))
+    );
 
     // Check NFC, NFD, NFKC, and NFKD normalization.
     let nfc = input.chars().nfc().collect::<String>();

--- a/tests/test_streamsafe_regression.rs
+++ b/tests/test_streamsafe_regression.rs
@@ -1,5 +1,5 @@
 use unicode_normalization::{
-    char::canonical_combining_class, is_nfc, is_nfc_stream_safe, UnicodeNormalization,
+    is_nfc, is_nfc_stream_safe, UnicodeNormalization,
 };
 
 #[test]


### PR DESCRIPTION
This is just some minor cleanups: using a local path dependency instead of a versioned dependency, using `assert_ne!` instead of doing it manually, and, fixing a warning.
