### PR TITLE
Flush the recomposition buffer when '\n' or CGJ are seen.

### DIFF
--- a/scripts/unicode.py
+++ b/scripts/unicode.py
@@ -99,9 +99,15 @@ class UnicodeData(object):
                 self.combining_classes[char_int] = cc
 
             if decomp.startswith('<'):
-                self.compat_decomp[char_int] = [int(c, 16) for c in decomp.split()[1:]]
+                compat_decomp_parts = [int(c, 16) for c in decomp.split()[1:]]
+                for c in compat_decomp_parts:
+                    assert not never_composes(c)
+                self.compat_decomp[char_int] = compat_decomp_parts
             elif decomp != '':
-                self.canon_decomp[char_int] = [int(c, 16) for c in decomp.split()]
+                canon_decomp_parts = [int(c, 16) for c in decomp.split()]
+                for c in canon_decomp_parts:
+                    assert not never_composes(c)
+                self.canon_decomp[char_int] = canon_decomp_parts
 
             if category == 'M' or 'M' in expanded_categories.get(category, []):
                 self.general_category_mark.append(char_int)
@@ -472,6 +478,12 @@ def minimal_perfect_hash(d):
                 # significant slowdown.
                 exit(1)
     return (salts, keys)
+
+# We assume that `\n` and `\u{34f}` (CGJ) never compose, so we can
+# always flush the recomposition buffer immediately when we see
+# them. See `never_composes` in src/normalize.rs for details.
+def never_composes(c):
+    return c == 0xa or c == 0x34f
 
 if __name__ == '__main__':
     data = UnicodeData()

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -72,15 +72,6 @@ pub fn compose(a: char, b: char) -> Option<char> {
     compose_hangul(a, b).or_else(|| composition_table(a, b))
 }
 
-/// Is the given `char` known to never compose with anything else?
-#[inline]
-pub(crate) fn never_composes(ch: char) -> bool {
-    // '\n' and U+34F (CGJ) are particularly useful codepoints that are known
-    // to never compose with anything, and recomposition should drain its
-    // buffer when it sees them.
-    ch == '\n' || ch == '\u{34f}'
-}
-
 // Constants from Unicode 9.0.0 Section 3.12 Conjoining Jamo Behavior
 // http://www.unicode.org/versions/Unicode9.0.0/ch03.pdf#M9.32468.Heading.310.Combining.Jamo.Behavior
 const S_BASE: u32 = 0xAC00;

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -72,6 +72,15 @@ pub fn compose(a: char, b: char) -> Option<char> {
     compose_hangul(a, b).or_else(|| composition_table(a, b))
 }
 
+/// Is the given `char` known to never compose with anything else?
+#[inline]
+pub(crate) fn never_composes(ch: char) -> bool {
+    // '\n' and U+34F (CGJ) are particularly useful codepoints that are known
+    // to never compose with anything, and recomposition should drain its
+    // buffer when it sees them.
+    ch == '\n' || ch == '\u{34f}'
+}
+
 // Constants from Unicode 9.0.0 Section 3.12 Conjoining Jamo Behavior
 // http://www.unicode.org/versions/Unicode9.0.0/ch03.pdf#M9.32468.Heading.310.Combining.Jamo.Behavior
 const S_BASE: u32 = 0xAC00;

--- a/src/recompose.rs
+++ b/src/recompose.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use crate::decompose::Decompositions;
-use crate::normalize::never_composes;
+use crate::tables::assume_never_composes;
 use core::fmt::{self, Write};
 use tinyvec::TinyVec;
 
@@ -68,7 +68,7 @@ impl<I: Iterator<Item = char>> Iterator for Recompositions<I> {
                             None => {
                                 // Nothing to compose with; if this isn't a starter or it
                                 // never composes, just return it immediately.
-                                if ch_class != 0 || never_composes(ch) {
+                                if ch_class != 0 || assume_never_composes(ch) {
                                     return Some(ch);
                                 }
                                 self.composee = Some(ch);
@@ -85,7 +85,7 @@ impl<I: Iterator<Item = char>> Iterator for Recompositions<I> {
                                 None => {
                                     // `ch` didn't compose with `composee`. If `ch` never composes,
                                     // drain the buffer.
-                                    if never_composes(ch) {
+                                    if assume_never_composes(ch) {
                                         self.state = Purging(0);
                                         self.buffer.push(ch);
                                         self.composee = None;
@@ -104,7 +104,7 @@ impl<I: Iterator<Item = char>> Iterator for Recompositions<I> {
                                 if l_class >= ch_class {
                                     // `ch` is blocked from `composee`. If `ch` never composes,
                                     // drain the buffer.
-                                    if never_composes(ch) {
+                                    if assume_never_composes(ch) {
                                         self.state = Purging(0);
                                         self.buffer.push(ch);
                                         self.composee = None;

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -23325,3 +23325,9 @@ pub(crate) const TRAILING_NONSTARTERS_KV: &[u32] = &[
 ];
 
 
+#[inline]
+pub(crate) fn assume_never_composes(c: char) -> bool {
+    false || c == '\u{34f}' || c == '\u{a}'
+}
+
+

--- a/tests/test_nfc_nobuffer_newline_or_cgj.rs
+++ b/tests/test_nfc_nobuffer_newline_or_cgj.rs
@@ -1,5 +1,5 @@
 //! Test that the NFC iterator flushes its buffer immediately after seeting a
-//! '\n' or '\34f' (CGJ), as those characters never compose with anything.
+//! '\n' or '\u{34f}' (CGJ), as those characters never compose with anything.
 
 use unicode_normalization::UnicodeNormalization;
 

--- a/tests/test_nfc_nobuffer_newline_or_cgj.rs
+++ b/tests/test_nfc_nobuffer_newline_or_cgj.rs
@@ -1,0 +1,90 @@
+//! Test that the NFC iterator flushes its buffer immediately after seeting a
+//! '\n' or '\34f' (CGJ), as those characters never compose with anything.
+
+use unicode_normalization::UnicodeNormalization;
+
+/// Iterate through a given data buffer, expecting to stop at a given stop index.
+struct Limited {
+    data: Vec<char>,
+    stop: usize,
+    i: usize,
+}
+
+impl Limited {
+    fn new(data: Vec<char>, stop: usize) -> Self {
+        Self { data, stop, i: 0 }
+    }
+}
+
+impl Iterator for Limited {
+    type Item = char;
+
+    fn next(&mut self) -> Option<char> {
+        assert!(self.i < self.stop, "next() called too many times");
+        let result = self.data.get(self.i);
+        self.i += 1;
+        result.cloned()
+    }
+}
+
+#[test]
+fn test_nfc_nobuffer_newline() {
+    let mut s = Limited::new(vec!['a', 'b', 'c', '\n', 'd', 'e', 'f'], 4).nfc();
+    assert_eq!(s.next(), Some('a'));
+    assert_eq!(s.next(), Some('b'));
+    assert_eq!(s.next(), Some('c'));
+    assert_eq!(s.next(), Some('\n'));
+}
+
+#[test]
+fn test_nfc_nobuffer_newline_at_start() {
+    let mut s = Limited::new(vec!['\n', 'd', 'e', 'f'], 1).nfc();
+    assert_eq!(s.next(), Some('\n'));
+}
+
+#[test]
+fn test_nfc_nobuffer_newline_after_combine() {
+    let mut s = Limited::new(vec!['A', '\u{30a}', '\n', 'd', 'e', 'f'], 3).nfc();
+    assert_eq!(s.next(), Some('\u{c5}'));
+    assert_eq!(s.next(), Some('\n'));
+}
+
+#[test]
+fn test_nfc_nobuffer_newline_after_block() {
+    let mut s = Limited::new(vec![',', ')', '\u{30f}', '\n', '\u{30f}'], 4).nfc();
+    s.next();
+    s.next();
+    s.next();
+    s.next();
+}
+
+#[test]
+fn test_nfc_nobuffer_cgj() {
+    let mut s = Limited::new(vec!['a', 'b', 'c', '\u{34f}', 'd', 'e', 'f'], 4).nfc();
+    assert_eq!(s.next(), Some('a'));
+    assert_eq!(s.next(), Some('b'));
+    assert_eq!(s.next(), Some('c'));
+    assert_eq!(s.next(), Some('\u{34f}'));
+}
+
+#[test]
+fn test_nfc_nobuffer_cgj_at_start() {
+    let mut s = Limited::new(vec!['\u{34f}', 'd', 'e', 'f'], 1).nfc();
+    assert_eq!(s.next(), Some('\u{34f}'));
+}
+
+#[test]
+fn test_nfc_nobuffer_cgj_after_combine() {
+    let mut s = Limited::new(vec!['A', '\u{30a}', '\u{34f}', 'd', 'e', 'f'], 3).nfc();
+    assert_eq!(s.next(), Some('\u{c5}'));
+    assert_eq!(s.next(), Some('\u{34f}'));
+}
+
+#[test]
+fn test_nfc_nobuffer_cgj_after_block() {
+    let mut s = Limited::new(vec![',', ')', '\u{30f}', '\u{34f}', '\u{30f}'], 4).nfc();
+    s.next();
+    s.next();
+    s.next();
+    s.next();
+}

--- a/tests/test_nfc_nobuffer_newline_or_cgj.rs
+++ b/tests/test_nfc_nobuffer_newline_or_cgj.rs
@@ -23,7 +23,7 @@ impl Iterator for Limited {
         assert!(self.i < self.stop, "next() called too many times");
         let result = self.data.get(self.i);
         self.i += 1;
-        result.cloned()
+        result.copied()
     }
 }
 

--- a/tests/test_nfc_nobuffer_newline_or_cgj.rs
+++ b/tests/test_nfc_nobuffer_newline_or_cgj.rs
@@ -52,10 +52,10 @@ fn test_nfc_nobuffer_newline_after_combine() {
 #[test]
 fn test_nfc_nobuffer_newline_after_block() {
     let mut s = Limited::new(vec![',', ')', '\u{30f}', '\n', '\u{30f}'], 4).nfc();
-    s.next();
-    s.next();
-    s.next();
-    s.next();
+    assert_eq!(s.next(), Some(','));
+    assert_eq!(s.next(), Some(')'));
+    assert_eq!(s.next(), Some('\u{30f}'));
+    assert_eq!(s.next(), Some('\n'));
 }
 
 #[test]
@@ -83,8 +83,8 @@ fn test_nfc_nobuffer_cgj_after_combine() {
 #[test]
 fn test_nfc_nobuffer_cgj_after_block() {
     let mut s = Limited::new(vec![',', ')', '\u{30f}', '\u{34f}', '\u{30f}'], 4).nfc();
-    s.next();
-    s.next();
-    s.next();
-    s.next();
+    assert_eq!(s.next(), Some(','));
+    assert_eq!(s.next(), Some(')'));
+    assert_eq!(s.next(), Some('\u{30f}'));
+    assert_eq!(s.next(), Some('\u{34f}'));
 }


### PR DESCRIPTION
'\n' and CGJ never compose with anything, so when we see them we can
immediately yield them as valid recomposed forms, rather than buffering
them and finding out later that they don't happen to compose.

This PR is fairly niche -- in my use case, I'm translating strings from a dynamic source and it's desirable to let the NFC iterator yield a '\n' immediately so that the consumer can process a line without first waiting for the first character from the following line to become available. Similarly, if the producer wants to ensure the consumer sees some output, it's nice if a CGJ is sufficient to tell NFC to drain the buffer. But it does make the recomposition logic more complex, so I'll understand if you don't want to accept this.