### PR TITLE
Publish 0.1.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "unicode-normalization"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["kwantam <kwantam@gmail.com>", "Manish Goregaokar <manishsmail@gmail.com>"]
 
 homepage = "https://github.com/unicode-rs/unicode-normalization"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-unicode-normalization = "0.1.18"
+unicode-normalization = "0.1.19"
 ```
 
 ## `no_std` + `alloc` support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! unicode-normalization = "0.1.18"
+//! unicode-normalization = "0.1.19"
 //! ```
 
 #![deny(missing_docs, unsafe_code)]


### PR DESCRIPTION
Bump the version number to 0.1.19 to prepare for a release containing the bug fix for `is_public_assigned`.