### PR TITLE
Fix #58, add cargo feature to remove liballoc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ version = "1"
 
 [features]
 default = ["std", "alloc"]
-std = []
+std = ["alloc"]
 alloc = ["tinyvec/alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ exclude = [ "target/*", "Cargo.lock", "scripts/tmp", "*.txt", "tests/*" ]
 
 [dependencies.tinyvec]
 version = "1"
-features = ["alloc"]
 
 
 [features]
-default = ["std"]
+default = ["std", "alloc"]
 std = []
+alloc = ["tinyvec/alloc"]

--- a/src/decompose.rs
+++ b/src/decompose.rs
@@ -10,7 +10,10 @@
 use core::fmt::{self, Write};
 use core::iter::Fuse;
 use core::ops::Range;
-use tinyvec::TinyVec;
+#[cfg(feature = "alloc")]
+type VecType<T> = tinyvec::TinyVec::<[T; 4]>;
+#[cfg(not(feature = "alloc"))]
+type VecType<T> = tinyvec::ArrayVec::<[T; 128]>;
 
 #[derive(Clone)]
 enum DecompositionType {
@@ -32,7 +35,7 @@ pub struct Decompositions<I> {
     // 2) "Ready" characters which are sorted and ready to emit on demand;
     // 3) A "pending" block which stills needs more characters for us to be able
     //    to sort in canonical order and is not safe to emit.
-    buffer: TinyVec<[(u8, char); 4]>,
+    buffer: VecType<(u8, char)>,
     ready: Range<usize>,
 }
 
@@ -41,7 +44,7 @@ pub fn new_canonical<I: Iterator<Item = char>>(iter: I) -> Decompositions<I> {
     Decompositions {
         kind: self::DecompositionType::Canonical,
         iter: iter.fuse(),
-        buffer: TinyVec::new(),
+        buffer: VecType::new(),
         ready: 0..0,
     }
 }
@@ -51,7 +54,7 @@ pub fn new_compatible<I: Iterator<Item = char>>(iter: I) -> Decompositions<I> {
     Decompositions {
         kind: self::DecompositionType::Compatible,
         iter: iter.fuse(),
-        buffer: TinyVec::new(),
+        buffer: VecType::new(),
         ready: 0..0,
     }
 }

--- a/src/recompose.rs
+++ b/src/recompose.rs
@@ -10,7 +10,12 @@
 
 use crate::decompose::Decompositions;
 use core::fmt::{self, Write};
-use tinyvec::TinyVec;
+#[cfg(feature = "alloc")]
+type VecType<T> = tinyvec::TinyVec::<[T; 4]>;
+#[cfg(not(feature = "alloc"))]
+type VecType<T> = tinyvec::ArrayVec::<[T; 128]>;
+
+
 
 #[derive(Clone)]
 enum RecompositionState {
@@ -24,7 +29,7 @@ enum RecompositionState {
 pub struct Recompositions<I> {
     iter: Decompositions<I>,
     state: RecompositionState,
-    buffer: TinyVec<[char; 4]>,
+    buffer: VecType<char>,
     composee: Option<char>,
     last_ccc: Option<u8>,
 }
@@ -34,7 +39,7 @@ pub fn new_canonical<I: Iterator<Item = char>>(iter: I) -> Recompositions<I> {
     Recompositions {
         iter: super::decompose::new_canonical(iter),
         state: self::RecompositionState::Composing,
-        buffer: TinyVec::new(),
+        buffer: VecType::new(),
         composee: None,
         last_ccc: None,
     }
@@ -45,7 +50,7 @@ pub fn new_compatible<I: Iterator<Item = char>>(iter: I) -> Recompositions<I> {
     Recompositions {
         iter: super::decompose::new_compatible(iter),
         state: self::RecompositionState::Composing,
-        buffer: TinyVec::new(),
+        buffer: VecType::new(),
         composee: None,
         last_ccc: None,
     }


### PR DESCRIPTION
Uses conditional compilation to swap out the vec implementation. Prefers a non-panic variant when `alloc` is enabled. `alloc` is enabled by default.