### PR TITLE
RFC: Switch from tinyvec to smallvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,8 @@ edition = "2018"
 
 exclude = [ "target/*", "Cargo.lock", "scripts/tmp", "*.txt", "tests/*" ]
 
-[dependencies.tinyvec]
-version = "1"
-features = ["alloc"]
-
+[dependencies]
+smallvec = "1"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.20"
 authors = ["kwantam <kwantam@gmail.com>", "Manish Goregaokar <manishsmail@gmail.com>"]
 
 homepage = "https://github.com/unicode-rs/unicode-normalization"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate core;
 
-extern crate tinyvec;
+extern crate smallvec;
 
 pub use crate::decompose::Decompositions;
 pub use crate::quick_check::{

--- a/src/recompose.rs
+++ b/src/recompose.rs
@@ -10,7 +10,7 @@
 
 use crate::decompose::Decompositions;
 use core::fmt::{self, Write};
-use tinyvec::TinyVec;
+use smallvec::SmallVec;
 
 #[derive(Clone)]
 enum RecompositionState {
@@ -24,7 +24,7 @@ enum RecompositionState {
 pub struct Recompositions<I> {
     iter: Decompositions<I>,
     state: RecompositionState,
-    buffer: TinyVec<[char; 4]>,
+    buffer: SmallVec<[char; 4]>,
     composee: Option<char>,
     last_ccc: Option<u8>,
 }
@@ -34,7 +34,7 @@ pub fn new_canonical<I: Iterator<Item = char>>(iter: I) -> Recompositions<I> {
     Recompositions {
         iter: super::decompose::new_canonical(iter),
         state: self::RecompositionState::Composing,
-        buffer: TinyVec::new(),
+        buffer: SmallVec::new(),
         composee: None,
         last_ccc: None,
     }
@@ -45,7 +45,7 @@ pub fn new_compatible<I: Iterator<Item = char>>(iter: I) -> Recompositions<I> {
     Recompositions {
         iter: super::decompose::new_compatible(iter),
         state: self::RecompositionState::Composing,
-        buffer: TinyVec::new(),
+        buffer: SmallVec::new(),
         composee: None,
         last_ccc: None,
     }

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use core::fmt::{self, Write};
-use tinyvec::ArrayVec;
+use smallvec::SmallVec;
 
 /// External iterator for replacements for a string's characters.
 #[derive(Clone)]
@@ -36,7 +36,7 @@ impl<I: Iterator<Item = char>> Iterator for Replacements<I> {
         match self.iter.next() {
             Some(ch) => {
                 // At this time, the longest replacement sequence has length 2.
-                let mut buffer = ArrayVec::<[char; 2]>::new();
+                let mut buffer = SmallVec::<[char; 2]>::new();
                 super::char::decompose_cjk_compat_variants(ch, |d| buffer.push(d));
                 self.buffer = buffer.get(1).copied();
                 Some(buffer[0])


### PR DESCRIPTION
At least in Firefox, we use SmallVec extensively, and I'd love to avoid having two data structures doing fundamentally the same thing. It seems `SmallVec` is more popular in the ecosystem than `TinyVec`, so switch to it.

r? @Manishearth 