### PR TITLE
Directly expose constructors for iterators rather than relying on hard-to-discover trait stuff

### DIFF
--- a/src/decompose.rs
+++ b/src/decompose.rs
@@ -36,23 +36,33 @@ pub struct Decompositions<I> {
     ready: Range<usize>,
 }
 
-#[inline]
-pub fn new_canonical<I: Iterator<Item = char>>(iter: I) -> Decompositions<I> {
-    Decompositions {
-        kind: self::DecompositionType::Canonical,
-        iter: iter.fuse(),
-        buffer: TinyVec::new(),
-        ready: 0..0,
+impl<I: Iterator<Item = char>> Decompositions<I> {
+    /// Create a new decomposition iterator for canonical decompositions (NFD)
+    ///
+    /// Note that this iterator can also be obtained by directly calling [`.nfd()`](crate::UnicodeNormalization::nfd)
+    /// on the iterator.
+    #[inline]
+    pub fn new_canonical(iter: I) -> Decompositions<I> {
+        Decompositions {
+            kind: self::DecompositionType::Canonical,
+            iter: iter.fuse(),
+            buffer: TinyVec::new(),
+            ready: 0..0,
+        }
     }
-}
 
-#[inline]
-pub fn new_compatible<I: Iterator<Item = char>>(iter: I) -> Decompositions<I> {
-    Decompositions {
-        kind: self::DecompositionType::Compatible,
-        iter: iter.fuse(),
-        buffer: TinyVec::new(),
-        ready: 0..0,
+    /// Create a new decomposition iterator for compatability decompositions (NFkD)
+    ///
+    /// Note that this iterator can also be obtained by directly calling [`.nfd()`](crate::UnicodeNormalization::nfd)
+    /// on the iterator.
+    #[inline]
+    pub fn new_compatible(iter: I) -> Decompositions<I> {
+        Decompositions {
+            kind: self::DecompositionType::Compatible,
+            iter: iter.fuse(),
+            buffer: TinyVec::new(),
+            ready: 0..0,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,22 +133,22 @@ pub trait UnicodeNormalization<I: Iterator<Item = char>> {
 impl<'a> UnicodeNormalization<Chars<'a>> for &'a str {
     #[inline]
     fn nfd(self) -> Decompositions<Chars<'a>> {
-        decompose::new_canonical(self.chars())
+        Decompositions::new_canonical(self.chars())
     }
 
     #[inline]
     fn nfkd(self) -> Decompositions<Chars<'a>> {
-        decompose::new_compatible(self.chars())
+        Decompositions::new_compatible(self.chars())
     }
 
     #[inline]
     fn nfc(self) -> Recompositions<Chars<'a>> {
-        recompose::new_canonical(self.chars())
+        Recompositions::new_canonical(self.chars())
     }
 
     #[inline]
     fn nfkc(self) -> Recompositions<Chars<'a>> {
-        recompose::new_compatible(self.chars())
+        Recompositions::new_compatible(self.chars())
     }
 
     #[inline]
@@ -165,22 +165,22 @@ impl<'a> UnicodeNormalization<Chars<'a>> for &'a str {
 impl UnicodeNormalization<option::IntoIter<char>> for char {
     #[inline]
     fn nfd(self) -> Decompositions<option::IntoIter<char>> {
-        decompose::new_canonical(Some(self).into_iter())
+        Decompositions::new_canonical(Some(self).into_iter())
     }
 
     #[inline]
     fn nfkd(self) -> Decompositions<option::IntoIter<char>> {
-        decompose::new_compatible(Some(self).into_iter())
+        Decompositions::new_compatible(Some(self).into_iter())
     }
 
     #[inline]
     fn nfc(self) -> Recompositions<option::IntoIter<char>> {
-        recompose::new_canonical(Some(self).into_iter())
+        Recompositions::new_canonical(Some(self).into_iter())
     }
 
     #[inline]
     fn nfkc(self) -> Recompositions<option::IntoIter<char>> {
-        recompose::new_compatible(Some(self).into_iter())
+        Recompositions::new_compatible(Some(self).into_iter())
     }
 
     #[inline]
@@ -197,22 +197,22 @@ impl UnicodeNormalization<option::IntoIter<char>> for char {
 impl<I: Iterator<Item = char>> UnicodeNormalization<I> for I {
     #[inline]
     fn nfd(self) -> Decompositions<I> {
-        decompose::new_canonical(self)
+        Decompositions::new_canonical(self)
     }
 
     #[inline]
     fn nfkd(self) -> Decompositions<I> {
-        decompose::new_compatible(self)
+        Decompositions::new_compatible(self)
     }
 
     #[inline]
     fn nfc(self) -> Recompositions<I> {
-        recompose::new_canonical(self)
+        Recompositions::new_canonical(self)
     }
 
     #[inline]
     fn nfkc(self) -> Recompositions<I> {
-        recompose::new_compatible(self)
+        Recompositions::new_compatible(self)
     }
 
     #[inline]

--- a/src/recompose.rs
+++ b/src/recompose.rs
@@ -32,25 +32,35 @@ pub struct Recompositions<I> {
     last_ccc: Option<u8>,
 }
 
-#[inline]
-pub fn new_canonical<I: Iterator<Item = char>>(iter: I) -> Recompositions<I> {
-    Recompositions {
-        iter: super::decompose::new_canonical(iter),
-        state: self::RecompositionState::Composing,
-        buffer: TinyVec::new(),
-        composee: None,
-        last_ccc: None,
+impl<I: Iterator<Item = char>> Recompositions<I> {
+    /// Create a new recomposition iterator for canonical compositions (NFC)
+    ///
+    /// Note that this iterator can also be obtained by directly calling [`.nfc()`](crate::UnicodeNormalization::nfc)
+    /// on the iterator.
+    #[inline]
+    pub fn new_canonical(iter: I) -> Self {
+        Recompositions {
+            iter: Decompositions::new_canonical(iter),
+            state: self::RecompositionState::Composing,
+            buffer: TinyVec::new(),
+            composee: None,
+            last_ccc: None,
+        }
     }
-}
 
-#[inline]
-pub fn new_compatible<I: Iterator<Item = char>>(iter: I) -> Recompositions<I> {
-    Recompositions {
-        iter: super::decompose::new_compatible(iter),
-        state: self::RecompositionState::Composing,
-        buffer: TinyVec::new(),
-        composee: None,
-        last_ccc: None,
+    /// Create a new recomposition iterator for compatability compositions (NFkC)
+    ///
+    /// Note that this iterator can also be obtained by directly calling [`.nfkc()`](crate::UnicodeNormalization::nfkc)
+    /// on the iterator.
+    #[inline]
+    pub fn new_compatible(iter: I) -> Self {
+        Recompositions {
+            iter: Decompositions::new_compatible(iter),
+            state: self::RecompositionState::Composing,
+            buffer: TinyVec::new(),
+            composee: None,
+            last_ccc: None,
+        }
     }
 }
 


### PR DESCRIPTION
It took me a while to realize these constructors were even available. Adding explicit functions for people who wish to track this.