### PR TITLE
OSS-Fuzz: Add new fuzzer upstream

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -23,5 +23,11 @@ path = "fuzz_targets/streaming.rs"
 test = false
 doc = false
 
+[[bin]]
+name = "process"
+path = "fuzz_targets/process.rs"
+test = false
+doc = false
+
 # Work around https://github.com/rust-lang/cargo/issues/8338
 [workspace]

--- a/fuzz/fuzz_targets/process.rs
+++ b/fuzz/fuzz_targets/process.rs
@@ -8,7 +8,10 @@ extern crate libfuzzer_sys;
 extern crate unicode_normalization;
 
 use unicode_normalization::{
-    char::{compose, canonical_combining_class, is_combining_mark, decompose_canonical, decompose_compatible},
+    char::{
+        canonical_combining_class, compose, decompose_canonical, decompose_compatible,
+        is_combining_mark,
+    },
     UnicodeNormalization,
 };
 
@@ -33,7 +36,10 @@ fuzz_target!(|data: &[u8]| {
     } else {
         None
     };
-    let string_data: String = data.iter().filter_map(|&b| std::char::from_u32(b as u32)).collect();
+    let string_data: String = data
+        .iter()
+        .filter_map(|&b| std::char::from_u32(b as u32))
+        .collect();
 
     // Randomly choose a function target
     match data.first().map(|&b| b % 10) {

--- a/fuzz/fuzz_targets/process.rs
+++ b/fuzz/fuzz_targets/process.rs
@@ -1,0 +1,74 @@
+// The fuzzing harness fuzz test some of the the
+// unicode string normalization processing
+
+#![no_main]
+
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate unicode_normalization;
+
+use unicode_normalization::{
+    char::{compose, canonical_combining_class, is_combining_mark, decompose_canonical, decompose_compatible},
+    UnicodeNormalization,
+};
+
+fuzz_target!(|data: &[u8]| {
+    let mut data = data;
+    let c = if let Some((char_value, remaining_data)) = data.split_first() {
+        match std::char::from_u32(*char_value as u32) {
+            Some(ch) => {
+                data = remaining_data;
+                ch
+            }
+            None => return,
+        }
+    } else {
+        return;
+    };
+
+    // Generate second character for fuzzing if data is enough
+    let c2 = if let Some((char_value, remaining_data)) = data.split_first() {
+        data = remaining_data;
+        std::char::from_u32(*char_value as u32)
+    } else {
+        None
+    };
+    let string_data: String = data.iter().filter_map(|&b| std::char::from_u32(b as u32)).collect();
+
+    // Randomly choose a function target
+    match data.first().map(|&b| b % 10) {
+        Some(0) => {
+            if let Some(c2) = c2 {
+                let _ = compose(c, c2);
+            }
+        }
+        Some(1) => {
+            let _ = canonical_combining_class(c);
+        }
+        Some(2) => {
+            let _ = is_combining_mark(c);
+        }
+        Some(3) => {
+            let _ = string_data.nfc().collect::<String>();
+        }
+        Some(4) => {
+            let _ = string_data.nfkd().collect::<String>();
+        }
+        Some(5) => {
+            let _ = string_data.nfd().collect::<String>();
+        }
+        Some(6) => {
+            let _ = string_data.nfkc().collect::<String>();
+        }
+        Some(7) => {
+            let _ = string_data.stream_safe().collect::<String>();
+        }
+        Some(8) => {
+            decompose_canonical(c, |_| {});
+        }
+        Some(9) => {
+            decompose_compatible(c, |_| {});
+        }
+        _ => {}
+    }
+});


### PR DESCRIPTION
I’ve noticed that this project is already included in OSS-Fuzz for fuzzing (https://github.com/google/oss-fuzz/tree/39036e0ed94fefa958d7c9a20a69619c832b682a/projects/unicode-rs), although the current code coverage appears to be limited. This PR proposes adding a new fuzzer that targets specific functions for Unicode string processing, with the goal of expanding the fuzzing scope and improving code exploration. I’d be grateful for any feedback or suggested changes. Thank you.