### PR TITLE
Give example on how to filter out diacritics

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ fn main() {
     let s = "ÅΩ";
     let c = s.nfc().collect::<String>();
     assert_eq!(c, "ÅΩ");
+
+    let s = "cafè";
+    // diacritics are not part of ascii thus get filtered out.
+    let c = s.nfkd().filter(|c| c.is_ascii()).collect::<String>();
+    assert_eq!(c, "cafe");
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,11 @@
 //!     let s = "ÅΩ";
 //!     let c = s.nfc().collect::<String>();
 //!     assert_eq!(c, "ÅΩ");
+//!
+//!     let s = "cafè";
+//!     // diacritics are not part of ascii thus get filtered out.
+//!     let c = s.nfkd().filter(|c| c.is_ascii()).collect::<String>();
+//!     assert_eq!(c, "cafe");
 //! }
 //! ```
 //!


### PR DESCRIPTION
Fix #84. Since there are a few people requesting this, myself included when I tried sorting this out, I'm adding this to the documentation as an example. 

This also showcases that strings are in fact decomposed in the iterator, which the initial example does not. 