### PR TITLE
Update CI, add note about MSRV, fix Clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,74 +14,119 @@ env:
   RUSTDOCFLAGS: -D warnings --cfg docsrs
 
 jobs:
-  build:
+  get-package-info:
     runs-on: ubuntu-latest
+    outputs:
+      msrv: ${{ steps.msrv.outputs.metadata }}
+      name: ${{ steps.name.outputs.metadata }}
+      version: ${{ steps.version.outputs.metadata }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get MSRV
+        id: msrv
+        uses: nicolaiunrein/cargo-get@v1.4.0
+        with:
+          subcommand: 'package.rust_version'
+      - name: Get package name
+        id: name
+        uses: nicolaiunrein/cargo-get@v1.4.0
+        with:
+          subcommand: 'package.name'
+      - name: Get package version
+        id: version
+        uses: nicolaiunrein/cargo-get@v1.4.0
+        with:
+          subcommand: 'package.version'
+
+  build_test:
+    needs: get-package-info
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ ubuntu-latest, windows-latest ]
         rust:
+          - ${{ needs.get-package-info.outputs.msrv }}
           - stable
           - beta
           - nightly
     steps:
-    - uses: actions/checkout@v2
-    - name: Install toolchain
-      uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests with all features
-      run: cargo test --all-features --verbose
-    - name: Run tests without features
-      run: cargo test --no-default-features --verbose
-    - name: Package
-      run: cargo package
-    - name: Test package
-      run: cd $(find target/package/ -maxdepth 1 -mindepth 1 -type d) && cargo test
-    - name: Test package without features
-      run: cd $(find target/package/ -maxdepth 1 -mindepth 1 -type d) && cargo test --no-default-features
-    - name: Build docs
-      if: matrix.rust == 'nightly'
-      run: cargo doc --all-features --verbose
-    - name: Check formatting
-      if: matrix.rust == 'stable'
-      run: cargo fmt --all --check
-    - name: Check clippy
-      if: matrix.rust == 'stable'
-      run: cargo clippy --all-features --lib --tests --examples --verbose
-    - name: Check benchmarks with clippy
-      if: matrix.rust == 'nightly'
-      run: cargo clippy --all-features --benches --verbose
-    - name: Check fuzz tests with clippy
-      if: matrix.rust == 'stable'
-      working-directory: fuzz
-      run: cargo clippy --all-features --all-targets --verbose
-    - name: Check fuzz tests formatting
-      if: matrix.rust == 'stable'
-      working-directory: fuzz
-      run: cargo fmt --all --check
-  msrv:
+      - name: Use tinyvec 1.6.0
+        if: matrix.rust == ${{ needs.get-package-info.outputs.msrv }}
+        run: cargo update -p tinyvec --precise 1.6.0
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests with all features
+        run: cargo test --all-features --verbose
+      - name: Run tests without features
+        run: cargo test --no-default-features --verbose
+      - name: Package
+        run: cargo package --offline
+      - name: Test package
+        working-directory: target/package/${{ needs.get-package-info.outputs.name }}-${{ needs.get-package-info.outputs.version }}/
+        run: cargo test --offline
+      - name: Test package without features
+        working-directory: target/package/${{ needs.get-package-info.outputs.name }}-${{ needs.get-package-info.outputs.version }}/
+        run: cargo test --no-default-features --offline
+
+  docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install msrv toolchain
-      uses: dtolnay/rust-toolchain@1.36.0
-    - name: Use tinyvec 1.6.0
-      run: cargo update -p tinyvec --precise 1.6.0
-    - name: Build
-      run: cargo build --verbose --all-features
+      - uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+      - name: Build docs
+        run: cargo doc --all-features --verbose
+
+  lints:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: Check formatting
+        run: cargo fmt --all --check
+      - name: Check clippy
+        run: cargo clippy --all-features --lib --tests --examples --verbose
+      - name: Check fuzz tests with clippy
+        working-directory: fuzz
+        run: cargo clippy --all-features --all-targets --verbose
+      - name: Check fuzz tests formatting
+        working-directory: fuzz
+        run: cargo fmt --all --check
+
+  bench-lints:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: rustfmt, clippy
+      - name: Check benchmarks with clippy
+        run: cargo clippy --all-features --benches --verbose
+
   regen:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-    - name: Regen
-      run: cd scripts && python3 unicode.py
-    - name: Diff tables
-      run: diff src/tables.rs scripts/tables.rs
-    - name: Diff tests
-      run: diff tests/data/normalization_tests.rs scripts/normalization_tests.rs
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Regen
+        run: cd scripts && python3 unicode.py
+      - name: Diff tables
+        run: diff src/tables.rs scripts/tables.rs
+      - name: Diff tests
+        run: diff tests/data/normalization_tests.rs scripts/normalization_tests.rs

--- a/README.md
+++ b/README.md
@@ -31,9 +31,21 @@ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-unicode-normalization = "0.1.23"
+unicode-normalization = "0.1.24"
 ```
 
 ## `no_std` + `alloc` support
 
 This crate is completely `no_std` + `alloc` compatible. This can be enabled by disabling the `std` feature, i.e. specifying `default-features = false` for this crate on your `Cargo.toml`.
+
+## Note about MSRV
+
+Dependencies' MSRVs evolve independently of this crate's MSRV.
+Old versions of cargo will always try to get the most recent versions of the dependencies.
+Therefore, if you are having troubles compiling on an old Rust version, try to install an older version of the incompatible dependency.
+
+For instance, to compile on Rust 1.36, `tinyvec` must be `<=1.6.0`
+
+```sh
+cargo update -p tinyvec --precise 1.6.0
+```

--- a/src/stream_safe.rs
+++ b/src/stream_safe.rs
@@ -41,10 +41,7 @@ impl<I: Iterator<Item = char>> Iterator for StreamSafe<I> {
 
     #[inline]
     fn next(&mut self) -> Option<char> {
-        let next_ch = match self.buffer.take().or_else(|| self.iter.next()) {
-            None => return None,
-            Some(c) => c,
-        };
+        let next_ch = self.buffer.take().or_else(|| self.iter.next())?;
         let d = classify_nonstarters(next_ch);
         if self.nonstarter_count + d.leading_nonstarters > MAX_NONSTARTERS {
             // Since we're emitting a CGJ, the suffix of the emitted string in NFKD has no trailing


### PR DESCRIPTION
Hello,
This pull request introduces some improvements:

**CI**
- Add `windows-latest` target (and make the CI platform independent)
- Treat `msrv` toolchain version as the same way as `stable`, `beta` and `nightly` by running also `cargo test`.
- drop depracated action `actions-rs` in favor of `dtolnay/rust-toolchain`

**README.md MSRV**

- explain how dependencies may require manual pinning for older Rust versions, like `tinyvec` for Rust 1.36.

**Clippy**

- fix Clippy complain about `src/stream_safe.rs`